### PR TITLE
Uart debug - add static prefix as yaml config option for uart-debug

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -177,7 +177,6 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
-CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
 DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix);"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
@@ -217,7 +216,6 @@ DEBUG_SCHEMA = cv.Schema(
         cv.Optional(CONF_DUMMY_RECEIVER, default=False): cv.boolean,
         cv.GenerateID(CONF_DUMMY_RECEIVER_ID): cv.declare_id(UARTDummyReceiver),
         cv.Optional(CONF_DEBUG_PREFIX, default=""): cv.string,
-        cv.Optional(CONF_DEBUG_ADD_SETTINGS, default=False): cv.boolean,
     }
 )
 
@@ -261,11 +259,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [
-                (UARTDirection, "direction"),
-                 (cg.std_vector.template(cg.uint8), "bytes"),
-                (cg.std_string, "debug_prefix")
-            ],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix")],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))
@@ -283,9 +277,6 @@ async def debug_to_code(config, parent):
         await cg.register_component(dummy, {})
     if CONF_DEBUG_PREFIX in config:
         cg.add(trigger.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
-    if config[CONF_DEBUG_ADD_SETTINGS]:
-        cg.add(trigger.set_debug_add_settings(config[CONF_DEBUG_PREFIX]))
-        cg.add_define("UART_DEBUGGER_ADD_SETTINGS")
     cg.add_define("USE_UART_DEBUGGER")
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, debug_add_uart_settings);"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, \"\");"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -280,7 +280,7 @@ async def debug_to_code(config, parent):
     if CONF_DEBUG_PREFIX in config:
         cg.add(trigger.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
     if config[CONF_DEBUG_ADD_SETTINGS]:
-        cg.add(parent.set_debug_add_settings(config[CONF_DEBUG_ADD_SETTINGS]))
+        cg.add(trigger.set_debug_add_settings(config[CONF_DEBUG_ADD_SETTINGS]))
     cg.add_define("USE_UART_DEBUGGER")
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, debug_add_uart_settings);"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, \"\");"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 
@@ -261,7 +261,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (bool, "debug_add_uart_settings")],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (cg.std_string, "")],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, \"\");"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, debug_add_uart_settings);"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 
@@ -261,7 +261,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (cg.std_string, "")],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (bool, "debug_add_uart_settings")],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -281,7 +281,7 @@ async def debug_to_code(config, parent):
     if CONF_DEBUG_PREFIX in config:
         cg.add(trigger.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
     if config[CONF_DEBUG_ADD_SETTINGS]:
-        cg.add(trigger.set_debug_add_settings(config[CONF_DEBUG_ADD_SETTINGS]))
+        cg.add(parent.set_debug_add_settings(config[CONF_DEBUG_ADD_SETTINGS]))
     cg.add_define("USE_UART_DEBUGGER")
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix);"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, '');"
 
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -256,7 +256,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def debug_to_code(config, parent):
-    trigger = cg.new_Pvariable(config[CONF_TRIGGER_ID], parent, config[CONF_DEBUG_ADD_SETTINGS])
+    trigger = cg.new_Pvariable(config[CONF_TRIGGER_ID], parent)
     await cg.register_component(trigger, config)
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
@@ -279,6 +279,8 @@ async def debug_to_code(config, parent):
         await cg.register_component(dummy, {})
     if CONF_DEBUG_PREFIX in config:
         cg.add(trigger.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
+    if config[CONF_DEBUG_ADD_SETTINGS]:
+        cg.add(trigger.set_debug_add_settings(config[CONF_DEBUG_PREFIX]))
     cg.add_define("USE_UART_DEBUGGER")
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', \"\");"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix);"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, 'none');"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, 'n');"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -278,9 +278,9 @@ async def debug_to_code(config, parent):
         dummy = cg.new_Pvariable(config[CONF_DUMMY_RECEIVER_ID], parent)
         await cg.register_component(dummy, {})
     if CONF_DEBUG_PREFIX in config:
-        cg.add(trigger.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
+        cg.add(parent.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
     if config[CONF_DEBUG_ADD_SETTINGS]:
-        cg.add(trigger.set_debug_add_settings(config[CONF_DEBUG_PREFIX]))
+        cg.add(parent.set_debug_add_settings(config[CONF_DEBUG_PREFIX]))
     cg.add_define("USE_UART_DEBUGGER")
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, \"\");"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, debug_add_uart_settings);"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 
@@ -261,7 +261,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (cg.std_string, "")],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (cg.bool, debug_add_uart_settings)],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, 'n');"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, \"\");"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -278,9 +278,9 @@ async def debug_to_code(config, parent):
         dummy = cg.new_Pvariable(config[CONF_DUMMY_RECEIVER_ID], parent)
         await cg.register_component(dummy, {})
     if CONF_DEBUG_PREFIX in config:
-        cg.add(parent.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
+        cg.add(trigger.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
     if config[CONF_DEBUG_ADD_SETTINGS]:
-        cg.add(parent.set_debug_add_settings(config[CONF_DEBUG_PREFIX]))
+        cg.add(trigger.set_debug_add_settings(config[CONF_DEBUG_PREFIX]))
     cg.add_define("USE_UART_DEBUGGER")
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -261,7 +261,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (bool, debug_add_uart_settings)],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (bool, "debug_add_uart_settings")],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -261,7 +261,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (std::string "debug_prefix")],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix")],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -285,6 +285,7 @@ async def debug_to_code(config, parent):
         cg.add(trigger.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
     if config[CONF_DEBUG_ADD_SETTINGS]:
         cg.add(trigger.set_debug_add_settings(config[CONF_DEBUG_PREFIX]))
+        cg.add_define("UART_DEBUGGER_ADD_SETTINGS")
     cg.add_define("USE_UART_DEBUGGER")
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix);"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, 'none');"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix);"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':');"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 
@@ -261,7 +261,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix")],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes")],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,8 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, '');"
-
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix);"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':');"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix);"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 
@@ -261,7 +261,11 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes")],
+            [
+                (UARTDirection, "direction"),
+                 (cg.std_vector.template(cg.uint8), "bytes"),
+                (cg.std_string, "debug_prefix")
+            ],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -261,7 +261,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (cg.bool, debug_add_uart_settings)],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (bool, debug_add_uart_settings)],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -256,7 +256,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def debug_to_code(config, parent):
-    trigger = cg.new_Pvariable(config[CONF_TRIGGER_ID], parent)
+    trigger = cg.new_Pvariable(config[CONF_TRIGGER_ID], parent, config[CONF_DEBUG_ADD_SETTINGS])
     await cg.register_component(trigger, config)
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
@@ -279,8 +279,6 @@ async def debug_to_code(config, parent):
         await cg.register_component(dummy, {})
     if CONF_DEBUG_PREFIX in config:
         cg.add(trigger.set_debug_prefix(config[CONF_DEBUG_PREFIX]))
-    if config[CONF_DEBUG_ADD_SETTINGS]:
-        cg.add(trigger.set_debug_add_settings(config[CONF_DEBUG_ADD_SETTINGS]))
     cg.add_define("USE_UART_DEBUGGER")
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':');"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', \"\");"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 
@@ -261,7 +261,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes")],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (std::string "debug_prefix")],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -178,7 +178,7 @@ AFTER_DEFAULTS = {CONF_BYTES: 150, CONF_TIMEOUT: "100ms"}
 # By default, log in hex format when no specific sequence is provided.
 CONF_DEBUG_PREFIX = "debug_prefix"
 CONF_DEBUG_ADD_SETTINGS = "debug_add_uart_settings"
-DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':', debug_prefix, \"\");"
+DEFAULT_DEBUG_OUTPUT = "UARTDebug::log_hex(direction, bytes, ':');"
 DEFAULT_SEQUENCE = [{CONF_LAMBDA: make_data_base(DEFAULT_DEBUG_OUTPUT)}]
 
 
@@ -261,7 +261,7 @@ async def debug_to_code(config, parent):
     for action in config[CONF_SEQUENCE]:
         await automation.build_automation(
             trigger,
-            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes"), (cg.std_string, "debug_prefix"), (bool, "debug_add_uart_settings")],
+            [(UARTDirection, "direction"), (cg.std_vector.template(cg.uint8), "bytes")],
             action,
         )
     cg.add(trigger.set_direction(config[CONF_DIRECTION]))

--- a/esphome/components/uart/uart_component.cpp
+++ b/esphome/components/uart/uart_component.cpp
@@ -33,7 +33,6 @@ void UARTComponent::set_rx_full_threshold_ms(uint8_t time) {
     // return settings string or empty if not desired
     if (!debug_add_settings)
       return "";
-    this->debug_add_settings_ = true;
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";
     res += std::to_string(this->get_stop_bits()) + ":";

--- a/esphome/components/uart/uart_component.cpp
+++ b/esphome/components/uart/uart_component.cpp
@@ -32,22 +32,22 @@ void UARTComponent::set_rx_full_threshold_ms(uint8_t time) {
   std::string UARTComponent::get_debug_settings_string() {
     // return settings string or empty if not desired
     if (!this->debug_add_settings_)
-      return "";
+      return this->debug_prefix_;
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";
     res += std::to_string(this->get_stop_bits()) + ":";
     switch(this->get_parity()) {
       case 0:
         res += "none|";
-        return res;
+        break;
       case 1:
         res += "even|";
-        return res;
+        break;
       case 2:
         res += "odd|";
-        return res;
+        break;
     }
-    return res;
+    return res + this->debug_prefix_;
   }
 #endif
 

--- a/esphome/components/uart/uart_component.cpp
+++ b/esphome/components/uart/uart_component.cpp
@@ -30,7 +30,7 @@ void UARTComponent::set_rx_full_threshold_ms(uint8_t time) {
 
 #ifdef USE_UART_DEBUGGER
   // return settings string or empty if not desired
-  std::string get_debug_settings_string(bool debug_add_settings_) {
+  std::string UARTComponent::get_debug_settings_string(bool debug_add_settings_) {
     this->debug_add_settings_ = true;
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";

--- a/esphome/components/uart/uart_component.cpp
+++ b/esphome/components/uart/uart_component.cpp
@@ -29,9 +29,9 @@ void UARTComponent::set_rx_full_threshold_ms(uint8_t time) {
 }
 
 #ifdef USE_UART_DEBUGGER
-  std::string UARTComponent::get_debug_settings_string(bool debug_add_settings_) {
+  std::string UARTComponent::get_debug_settings_string() {
     // return settings string or empty if not desired
-    if (!debug_add_settings)
+    if (!this->debug_add_settings_)
       return "";
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";

--- a/esphome/components/uart/uart_component.cpp
+++ b/esphome/components/uart/uart_component.cpp
@@ -29,8 +29,10 @@ void UARTComponent::set_rx_full_threshold_ms(uint8_t time) {
 }
 
 #ifdef USE_UART_DEBUGGER
-  // return settings string or empty if not desired
   std::string UARTComponent::get_debug_settings_string(bool debug_add_settings_) {
+    // return settings string or empty if not desired
+    if (!debug_add_settings)
+      return "";
     this->debug_add_settings_ = true;
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";

--- a/esphome/components/uart/uart_component.cpp
+++ b/esphome/components/uart/uart_component.cpp
@@ -28,28 +28,5 @@ void UARTComponent::set_rx_full_threshold_ms(uint8_t time) {
   this->set_rx_full_threshold(val);
 }
 
-#ifdef USE_UART_DEBUGGER
-  std::string UARTComponent::get_debug_settings_string() {
-    // return settings string or empty if not desired
-    if (!this->debug_add_settings_)
-      return this->debug_prefix_;
-    std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
-    res += std::to_string(this->get_data_bits()) + ":";
-    res += std::to_string(this->get_stop_bits()) + ":";
-    switch(this->get_parity()) {
-      case 0:
-        res += "none|";
-        break;
-      case 1:
-        res += "even|";
-        break;
-      case 2:
-        res += "odd|";
-        break;
-    }
-    return res + this->debug_prefix_;
-  }
-#endif
-
 }  // namespace uart
 }  // namespace esphome

--- a/esphome/components/uart/uart_component.cpp
+++ b/esphome/components/uart/uart_component.cpp
@@ -28,5 +28,27 @@ void UARTComponent::set_rx_full_threshold_ms(uint8_t time) {
   this->set_rx_full_threshold(val);
 }
 
+#ifdef USE_UART_DEBUGGER
+  // return settings string or empty if not desired
+  std::string get_debug_settings_string(bool debug_add_settings_) {
+    this->debug_add_settings_ = true;
+    std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
+    res += std::to_string(this->get_data_bits()) + ":";
+    res += std::to_string(this->get_stop_bits()) + ":";
+    switch(this->get_parity()) {
+      case 0:
+        res += "none|";
+        return res;
+      case 1:
+        res += "even|";
+        return res;
+      case 2:
+        res += "odd|";
+        return res;
+    }
+    return res;
+  }
+#endif
+
 }  // namespace uart
 }  // namespace esphome

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -150,6 +150,12 @@ class UARTComponent {
 #ifdef USE_UART_DEBUGGER
   // return settings string or empty if not desired
   std::string get_debug_settings_string();
+  void set_debug_prefix(std::string debug_prefix) { 
+    this->debug_prefix_ = debug_prefix;
+  }
+  void set_debug_add_settings(bool debug_add_settings) { 
+    this->debug_add_settings_ = debug_add_settings;
+  }
 #endif
 
 #if defined(USE_ESP8266) || defined(USE_ESP32)

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -152,13 +152,8 @@ class UARTComponent {
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
   std::string get_debug_prefix() const { return this->debug_prefix_; }
 
-  // get&set bool if settings shall be logged
-  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
-
   // return settings string or empty if not desired
   std::string get_debug_settings_string() {
-    if(!this->debug_add_settings_)
-      return "";
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";
     res += std::to_string(this->get_stop_bits()) + ":";
@@ -227,7 +222,6 @@ class UARTComponent {
 #ifdef USE_UART_DEBUGGER
   CallbackManager<void(UARTDirection, uint8_t, std::string, std::string)> debug_callback_{};
   std::string debug_prefix_{""};
-  bool debug_add_settings_{false};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -152,23 +152,28 @@ class UARTComponent {
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
   std::string get_debug_prefix() const { return this->debug_prefix_; }
 
+  // setter for bool if channel settings shall be added
+  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
+
   // return settings string or empty if not desired
-  void set_debug_settings_string() {
+  std::string set_debug_settings_string() {
+    if(!this->debug_add_settings_)
+      return "";
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";
     res += std::to_string(this->get_stop_bits()) + ":";
     switch(this->get_parity()) {
       case 0:
         res += "none|";
-        break;
+        return res;
       case 1:
         res += "even|";
-        break;
+        return res;
       case 2:
         res += "odd|";
-        break;
+        return res;
     }
-    this->settings_string_ = res;
+    return res;
   }
 #endif
 
@@ -222,7 +227,7 @@ class UARTComponent {
 #ifdef USE_UART_DEBUGGER
   CallbackManager<void(UARTDirection, uint8_t, std::string, bool)> debug_callback_{};
   std::string debug_prefix_{""};
-  std::string settings_string_{""};
+  bool debug_add_settings_{false};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -175,7 +175,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string debug_prefix)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
 #endif
@@ -195,7 +195,7 @@ class UARTComponent {
   uint8_t data_bits_;
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
-  CallbackManager<void(UARTDirection, uint8_t, std::string debug_prefix)> debug_callback_{};
+  CallbackManager<void(UARTDirection, uint8_t)> debug_callback_{};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -152,7 +152,7 @@ class UARTComponent {
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
   std::string get_debug_prefix() const { return this->debug_prefix_; }
 
-  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings__ = debug_add_settings; }
+  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
   // return settings string or empty if not desired
   std::string get_debug_settings_string();
 #endif

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -181,11 +181,11 @@ class UARTComponent {
   std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings) {
     if (!debug_add_settings)
       return debug_prefix;
-    std::string res = "|" + this->get_baud_rate();
-    res += ":" + this->get_data_bits();
-    res += ":" + this->get_stop_bits();
-    //res += ":" + static_cast<std::string>(esphome::uart::parity_to_str(this->parent_->get_parity()));
-    return res + debug_prefix;
+    std::string res = "|" + this->baud_rate_;
+    res += ":" + this->data_bits_;
+    res += ":" + this->stop_bits_;
+    res += ":" + static_cast<std::string>(esphome::uart::parity_to_str(this->parity_));
+    return res + "|" + debug_prefix;
 }
 #endif
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -9,6 +9,7 @@
 #include "esphome/core/helpers.h"
 #ifdef USE_UART_DEBUGGER
 #include "esphome/core/automation.h"
+#include "esphome/components/uart/uart_debugger.h"
 #endif
 
 namespace esphome {

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -179,7 +179,7 @@ class UARTComponent {
     this->debug_callback_.add(std::move(callback));
   }
   std::string UARTDebugger::get_debug_prefix(debug_prefix, bool debug_add_settings) {
-    if (!debug_add_settings_)
+    if (!debug_add_settings)
       return debug_prefix;
     std::string res = "|" + this->get_baud_rate();
     res += ":" + this->get_data_bits();

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -178,28 +178,6 @@ class UARTComponent {
   void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
-  std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings) {
-    if (!debug_add_settings)
-      return debug_prefix;
-    std::string res = "|" + this->baud_rate_;
-    res += ":" + this->data_bits_;
-    res += ":" + this->stop_bits_;
-    switch (this->parity_) {
-      case UART_CONFIG_PARITY_NONE:
-        res += "NONE";
-        break;
-      case UART_CONFIG_PARITY_EVEN:
-        res += "EVEN";
-        break;
-      case UART_CONFIG_PARITY_ODD:
-        res += "ODD";
-        break;
-    default:
-      res += "UNKNOWN";
-      break;
-    }
-    return res + "|" + debug_prefix;
-}
 #endif
 
  protected:

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -9,6 +9,7 @@
 #include "esphome/core/helpers.h"
 #ifdef USE_UART_DEBUGGER
 #include "esphome/core/automation.h"
+#include "esphome/components/uart/uart_debugger.h"
 #endif
 
 namespace esphome {
@@ -19,14 +20,6 @@ enum UARTParityOptions {
   UART_CONFIG_PARITY_EVEN,
   UART_CONFIG_PARITY_ODD,
 };
-
-#ifdef USE_UART_DEBUGGER
-enum UARTDirection {
-  UART_DIRECTION_RX,
-  UART_DIRECTION_TX,
-  UART_DIRECTION_BOTH,
-};
-#endif
 
 const LogString *parity_to_str(UARTParityOptions parity);
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -15,12 +15,6 @@
 namespace esphome {
 namespace uart {
 
-enum UARTParityOptions {
-  UART_CONFIG_PARITY_NONE,
-  UART_CONFIG_PARITY_EVEN,
-  UART_CONFIG_PARITY_ODD,
-};
-
 const LogString *parity_to_str(UARTParityOptions parity);
 
 class UARTComponent {

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -175,7 +175,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string debug_prefix)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
 #endif
@@ -195,7 +195,7 @@ class UARTComponent {
   uint8_t data_bits_;
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
-  CallbackManager<void(UARTDirection, uint8_t, std::string debug_prefix)> debug_callback_{};
+  CallbackManager<void(UARTDirection, uint8_t, std::string)> debug_callback_{};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -198,7 +198,6 @@ class UARTComponent {
       res += "UNKNOWN";
       break;
     }
-    res += ":" + static_cast<std::string>(esphome::uart::parity_to_str(this->parity_));
     return res + "|" + debug_prefix;
 }
 #endif

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -184,7 +184,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string, bool)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
 #endif

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -184,7 +184,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string debug_prefix)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
 #endif
@@ -204,7 +204,7 @@ class UARTComponent {
   uint8_t data_bits_;
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
-  CallbackManager<void(UARTDirection, uint8_t)> debug_callback_{};
+  CallbackManager<void(UARTDirection, uint8_t, std::string debug_prefix)> debug_callback_{};
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
 #endif

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -154,7 +154,7 @@ class UARTComponent {
 
   void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings__ = debug_add_settings; }
   // return settings string or empty if not desired
-  std::string get_debug_settings_string(bool debug_add_settings_);
+  std::string get_debug_settings_string();
 #endif
 
 #if defined(USE_ESP8266) || defined(USE_ESP32)

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -152,6 +152,10 @@ class UARTComponent {
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
   std::string get_debug_prefix() const { return this->debug_prefix_; }
 
+  // get&set bool if settings shall be logged
+  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
+  bool get_debug_add_settings() const { return this->debug_add_settings_; }
+
   // return settings string or empty if not desired
   std::string get_debug_settings_string() {
     if(!this->get_debug_add_settings())

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -152,12 +152,9 @@ class UARTComponent {
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
   std::string get_debug_prefix() const { return this->debug_prefix_; }
 
-  // setter for bool if channel settings shall be added
-  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
-
   // return settings string or empty if not desired
-  std::string get_debug_settings_string() {
-    if(!this->debug_add_settings_)
+  std::string get_debug_settings_string(bool debug_add_settings_) {
+    if(!debug_add_settings_)
       return "";
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";
@@ -227,7 +224,6 @@ class UARTComponent {
 #ifdef USE_UART_DEBUGGER
   CallbackManager<void(UARTDirection, uint8_t, std::string, bool)> debug_callback_{};
   std::string debug_prefix_{""};
-  bool debug_add_settings_{false};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -159,7 +159,7 @@ class UARTComponent {
   // return settings string or empty if not desired
   std::string get_debug_settings_string() {
     if(!this->get_debug_add_settings())
-      return;
+      return "";
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";
     res += std::to_string(this->get_stop_bits()) + ":";

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -178,6 +178,15 @@ class UARTComponent {
   void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
+  std::string UARTDebugger::get_debug_prefix(debug_prefix, bool debug_add_settings) {
+    if (!debug_add_settings_)
+      return debug_prefix;
+    std::string res = "|" + this->get_baud_rate();
+    res += ":" + this->get_data_bits();
+    res += ":" + this->get_stop_bits();
+    //res += ":" + static_cast<std::string>(esphome::uart::parity_to_str(this->parent_->get_parity()));
+    return res + debug_prefix;
+}
 #endif
 
  protected:

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -175,7 +175,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string = "")> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
   bool debugger_needs_reload() {

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -178,6 +178,9 @@ class UARTComponent {
   void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
+#endif
+
+#ifdef UART_DEBUGGER_ADD_SETTINGS
   bool debugger_needs_reload() {
     if(this->debugger_reload_required_) {
       this->debugger_reload_required_ = false;

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -162,7 +162,6 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void set_debugger(UARTDebugger* debugger) { this->debugger_ = debugger; }
   void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
@@ -184,7 +183,6 @@ class UARTComponent {
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
   CallbackManager<void(UARTDirection, uint8_t, std::string)> debug_callback_{};
-  UARTDebugger* debugger_;
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -14,6 +14,20 @@
 namespace esphome {
 namespace uart {
 
+enum UARTParityOptions {
+  UART_CONFIG_PARITY_NONE,
+  UART_CONFIG_PARITY_EVEN,
+  UART_CONFIG_PARITY_ODD,
+};
+
+#ifdef USE_UART_DEBUGGER
+enum UARTDirection {
+  UART_DIRECTION_RX,
+  UART_DIRECTION_TX,
+  UART_DIRECTION_BOTH,
+};
+#endif
+
 const LogString *parity_to_str(UARTParityOptions parity);
 
 class UARTComponent {

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -184,7 +184,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string, std::string)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
 #endif
@@ -204,7 +204,7 @@ class UARTComponent {
   uint8_t data_bits_;
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
-  CallbackManager<void(UARTDirection, uint8_t, std::string, std::string)> debug_callback_{};
+  CallbackManager<void(UARTDirection, uint8_t)> debug_callback_{};
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
 #endif

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -178,7 +178,7 @@ class UARTComponent {
   void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
-  std::string UARTDebugger::get_debug_prefix(debug_prefix, bool debug_add_settings) {
+  std::string get_debug_prefix(debug_prefix, bool debug_add_settings) {
     if (!debug_add_settings)
       return debug_prefix;
     std::string res = "|" + this->get_baud_rate();

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -148,11 +148,6 @@ class UARTComponent {
   uint32_t get_baud_rate() const { return baud_rate_; }
 
 #ifdef USE_UART_DEBUGGER
-  // get&set user defined log-string prefix
-  void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
-  std::string get_debug_prefix() const { return this->debug_prefix_; }
-
-  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
   // return settings string or empty if not desired
   std::string get_debug_settings_string();
 #endif

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -152,6 +152,7 @@ class UARTComponent {
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
   std::string get_debug_prefix() const { return this->debug_prefix_; }
 
+  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings__ = debug_add_settings; }
   // return settings string or empty if not desired
   std::string get_debug_settings_string(bool debug_add_settings_);
 #endif

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -175,7 +175,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string = "")> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
   bool debugger_needs_reload() {

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -178,6 +178,13 @@ class UARTComponent {
   void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
+  bool debugger_needs_reload() {
+    if(this->debugger_reload_required_) {
+      this->debugger_reload_required_ = false;
+      return true;
+    }
+    return false;
+  }
 #endif
 
  protected:
@@ -196,6 +203,7 @@ class UARTComponent {
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
   CallbackManager<void(UARTDirection, uint8_t, std::string)> debug_callback_{};
+  bool debugger_reload_required_{false};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -204,7 +204,7 @@ class UARTComponent {
   uint8_t data_bits_;
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
-  CallbackManager<void(UARTDirection, uint8_t, std::string, bool)> debug_callback_{};
+  CallbackManager<void(UARTDirection, uint8_t, std::string, std::string)> debug_callback_{};
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
 #endif

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -180,16 +180,6 @@ class UARTComponent {
   }
 #endif
 
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-  bool debugger_needs_reload() {
-    if(this->debugger_reload_required_) {
-      this->debugger_reload_required_ = false;
-      return true;
-    }
-    return false;
-  }
-#endif
-
  protected:
   virtual void check_logger_conflict() = 0;
   bool check_read_timeout_(size_t len = 1);
@@ -206,9 +196,6 @@ class UARTComponent {
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
   CallbackManager<void(UARTDirection, uint8_t, std::string)> debug_callback_{};
-#endif
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-  bool debugger_reload_required_{false};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -9,7 +9,6 @@
 #include "esphome/core/helpers.h"
 #ifdef USE_UART_DEBUGGER
 #include "esphome/core/automation.h"
-#include "esphome/components/uart/uart_debugger.h"
 #endif
 
 namespace esphome {

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -175,7 +175,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string debug_prefix)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
 #endif
@@ -195,7 +195,7 @@ class UARTComponent {
   uint8_t data_bits_;
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
-  CallbackManager<void(UARTDirection, uint8_t)> debug_callback_{};
+  CallbackManager<void(UARTDirection, uint8_t, std::string debug_prefix)> debug_callback_{};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -154,11 +154,10 @@ class UARTComponent {
 
   // get&set bool if settings shall be logged
   void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
-  bool get_debug_add_settings() const { return this->debug_add_settings_; }
 
   // return settings string or empty if not desired
   std::string get_debug_settings_string() {
-    if(!this->get_debug_add_settings())
+    if(!this->debug_add_settings_)
       return "";
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -196,6 +196,7 @@ class UARTComponent {
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
   CallbackManager<void(UARTDirection, uint8_t, std::string)> debug_callback_{};
+  UARTDebugger* debugger_;
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -156,6 +156,7 @@ class UARTComponent {
   std::string get_debug_settings_string(bool debug_add_settings_) {
     if(!debug_add_settings_)
       return "";
+    this->debug_add_settings = true;
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";
     res += std::to_string(this->get_stop_bits()) + ":";
@@ -224,6 +225,7 @@ class UARTComponent {
 #ifdef USE_UART_DEBUGGER
   CallbackManager<void(UARTDirection, uint8_t, std::string, bool)> debug_callback_{};
   std::string debug_prefix_{""};
+  bool debug_add_settings_{false};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -153,26 +153,7 @@ class UARTComponent {
   std::string get_debug_prefix() const { return this->debug_prefix_; }
 
   // return settings string or empty if not desired
-  std::string get_debug_settings_string(bool debug_add_settings_) {
-    if(!debug_add_settings_)
-      return "";
-    this->debug_add_settings_ = true;
-    std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
-    res += std::to_string(this->get_data_bits()) + ":";
-    res += std::to_string(this->get_stop_bits()) + ":";
-    switch(this->get_parity()) {
-      case 0:
-        res += "none|";
-        return res;
-      case 1:
-        res += "even|";
-        return res;
-      case 2:
-        res += "odd|";
-        return res;
-    }
-    return res;
-  }
+  std::string get_debug_settings_string(bool debug_add_settings_);
 #endif
 
 #if defined(USE_ESP8266) || defined(USE_ESP32)

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -184,6 +184,20 @@ class UARTComponent {
     std::string res = "|" + this->baud_rate_;
     res += ":" + this->data_bits_;
     res += ":" + this->stop_bits_;
+    switch (this->parity_) {
+      case UART_CONFIG_PARITY_NONE:
+        res += "NONE";
+        break;
+      case UART_CONFIG_PARITY_EVEN:
+        res += "EVEN";
+        break;
+      case UART_CONFIG_PARITY_ODD:
+        res += "ODD";
+        break;
+    default:
+      res += "UNKNOWN";
+      break;
+    }
     res += ":" + static_cast<std::string>(esphome::uart::parity_to_str(this->parity_));
     return res + "|" + debug_prefix;
 }

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -175,6 +175,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
+  void set_debugger(UARTDebugger* debugger) { this->debugger_ = debugger; }
   void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -186,7 +186,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string debug_prefix)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
 #endif
@@ -206,7 +206,7 @@ class UARTComponent {
   uint8_t data_bits_;
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
-  CallbackManager<void(UARTDirection, uint8_t, std::string debug_prefix)> debug_callback_{};
+  CallbackManager<void(UARTDirection, uint8_t)> debug_callback_{};
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
 #endif

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -152,10 +152,6 @@ class UARTComponent {
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
   std::string get_debug_prefix() const { return this->debug_prefix_; }
 
-  // get&set bool if settings shall be logged
-  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
-  bool get_debug_add_settings() const { return this->debug_add_settings_; }
-
   // return settings string or empty if not desired
   std::string get_debug_settings_string() {
     if(!this->get_debug_add_settings())

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -156,7 +156,7 @@ class UARTComponent {
   void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
 
   // return settings string or empty if not desired
-  std::string set_debug_settings_string() {
+  std::string get_debug_settings_string() {
     if(!this->debug_add_settings_)
       return "";
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -156,7 +156,7 @@ class UARTComponent {
   std::string get_debug_settings_string(bool debug_add_settings_) {
     if(!debug_add_settings_)
       return "";
-    this->debug_add_settings = true;
+    this->debug_add_settings_ = true;
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";
     res += std::to_string(this->get_stop_bits()) + ":";

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -147,17 +147,6 @@ class UARTComponent {
   // @return Baud rate in bits per second.
   uint32_t get_baud_rate() const { return baud_rate_; }
 
-#ifdef USE_UART_DEBUGGER
-  // return settings string or empty if not desired
-  std::string get_debug_settings_string();
-  void set_debug_prefix(std::string debug_prefix) { 
-    this->debug_prefix_ = debug_prefix;
-  }
-  void set_debug_add_settings(bool debug_add_settings) { 
-    this->debug_add_settings_ = debug_add_settings;
-  }
-#endif
-
 #if defined(USE_ESP8266) || defined(USE_ESP32)
   /**
    * Load the UART settings.
@@ -186,7 +175,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string debug_prefix)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
 #endif
@@ -206,9 +195,7 @@ class UARTComponent {
   uint8_t data_bits_;
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
-  CallbackManager<void(UARTDirection, uint8_t)> debug_callback_{};
-  std::string debug_prefix_{""};
-  bool debug_add_settings_{false};
+  CallbackManager<void(UARTDirection, uint8_t, std::string debug_prefix)> debug_callback_{};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -206,6 +206,8 @@ class UARTComponent {
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
   CallbackManager<void(UARTDirection, uint8_t, std::string)> debug_callback_{};
+#endif
+#ifdef UART_DEBUGGER_ADD_SETTINGS
   bool debugger_reload_required_{false};
 #endif
 };

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -153,7 +153,7 @@ class UARTComponent {
   std::string get_debug_prefix() const { return this->debug_prefix_; }
 
   // return settings string or empty if not desired
-  std::string get_debug_settings_string() {
+  void set_debug_settings_string() {
     std::string res = "|" + std::to_string(this->get_baud_rate()) + ":";
     res += std::to_string(this->get_data_bits()) + ":";
     res += std::to_string(this->get_stop_bits()) + ":";
@@ -168,7 +168,7 @@ class UARTComponent {
         res += "odd|";
         break;
     }
-    return res;
+    this->settings_string_ = res;
   }
 #endif
 
@@ -200,7 +200,7 @@ class UARTComponent {
 #endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
-  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string, std::string)> &&callback) {
+  void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string, bool)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
 #endif
@@ -220,8 +220,9 @@ class UARTComponent {
   uint8_t data_bits_;
   UARTParityOptions parity_;
 #ifdef USE_UART_DEBUGGER
-  CallbackManager<void(UARTDirection, uint8_t, std::string, std::string)> debug_callback_{};
+  CallbackManager<void(UARTDirection, uint8_t, std::string, bool)> debug_callback_{};
   std::string debug_prefix_{""};
+  std::string settings_string_{""};
 #endif
 };
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -178,7 +178,7 @@ class UARTComponent {
   void add_debug_callback(std::function<void(UARTDirection, uint8_t, std::string)> &&callback) {
     this->debug_callback_.add(std::move(callback));
   }
-  std::string get_debug_prefix(debug_prefix, bool debug_add_settings) {
+  std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings) {
     if (!debug_add_settings)
       return debug_prefix;
     std::string res = "|" + this->get_baud_rate();

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -156,7 +156,7 @@ void ESP8266UartComponent::write_array(const uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
 }
@@ -181,7 +181,7 @@ bool ESP8266UartComponent::read_array(uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -156,7 +156,7 @@ void ESP8266UartComponent::write_array(const uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], "");
   }
 #endif
 }
@@ -181,7 +181,7 @@ bool ESP8266UartComponent::read_array(uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], "");
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -225,7 +225,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
 }
@@ -265,7 +265,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -224,9 +224,8 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   uart_write_bytes(this->uart_num_, data, len);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
-  std::string debug_prefix = this->get_debug_settings_string();
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], debug_prefix);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i]);
   }
 #endif
 }
@@ -265,9 +264,8 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
     uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
-  std::string debug_prefix = this->get_debug_settings_string();
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], debug_prefix);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i]);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -225,7 +225,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i]);
   }
 #endif
 }
@@ -265,7 +265,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i]);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -171,7 +171,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   }
 
 #ifdef USE_UART_DEBUGGER
-  this->debugger_->reload(this);
+  this->debugger_reload_required_ = true;
 #endif
   
   if (dump_config) {

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -229,7 +229,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], "");
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i]);
   }
 #endif
 }
@@ -269,7 +269,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], "");
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i]);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -224,8 +224,8 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   uart_write_bytes(this->uart_num_, data, len);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
-  if (this->debug_add_settings_)
-    debug_prefix.insert(0, this->get_debug_settings_string());
+  std::string:: debug_prefix = this->get_debug_settings_string(this->debug_add_settings_)
+                              + this->debug_prefix_;
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_TX, data[i], debug_prefix);
   }
@@ -267,8 +267,8 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   std::string debug_prefix = this->debug_prefix_;
-  if (this->debug_add_settings_)
-    debug_prefix.insert(0, this->get_debug_settings_string());
+  std::string:: debug_prefix = this->get_debug_settings_string(this->debug_add_settings_)
+                              + this->debug_prefix_;
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_RX, data[i], debug_prefix);
   }

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -170,7 +170,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
-#ifdef USE_UART_DEBUGGER
+#ifdef UART_DEBUGGER_ADD_SETTINGS
   this->debugger_reload_required_ = true;
 #endif
   

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -265,7 +265,6 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
     uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
-  std::string debug_prefix = this->debug_prefix_;
   std::string debug_prefix = this->get_debug_settings_string() + this->debug_prefix_;
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_RX, data[i], debug_prefix);

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -225,7 +225,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i]);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], "");
   }
 #endif
 }
@@ -265,7 +265,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i]);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], "");
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -225,7 +225,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_);
   }
 #endif
 }
@@ -265,7 +265,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -170,6 +170,10 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
+#ifdef USE_UART_DEBUGGER
+  this->debugger_->reload(this);
+#endif
+  
   if (dump_config) {
     ESP_LOGCONFIG(TAG, "UART %u was reloaded.", this->uart_num_);
     this->dump_config();

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -224,7 +224,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   uart_write_bytes(this->uart_num_, data, len);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
-  std::string debug_prefix = this->get_debug_settings_string() + this->debug_prefix_;
+  std::string debug_prefix = this->get_debug_settings_string();
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_TX, data[i], debug_prefix);
   }
@@ -265,7 +265,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
     uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
-  std::string debug_prefix = this->get_debug_settings_string() + this->debug_prefix_;
+  std::string debug_prefix = this->get_debug_settings_string();
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_RX, data[i], debug_prefix);
   }

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -225,7 +225,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
 }
@@ -265,7 +265,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -229,7 +229,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i]);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], "");
   }
 #endif
 }

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -169,10 +169,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-  this->debugger_reload_required_ = true;
-#endif
   
   if (dump_config) {
     ESP_LOGCONFIG(TAG, "UART %u was reloaded.", this->uart_num_);

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -224,7 +224,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   uart_write_bytes(this->uart_num_, data, len);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
-  std::string:: debug_prefix = this->get_debug_settings_string() + this->debug_prefix_;
+  std::string debug_prefix = this->get_debug_settings_string() + this->debug_prefix_;
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_TX, data[i], debug_prefix);
   }

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -269,7 +269,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i]);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], "");
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -266,7 +266,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   std::string debug_prefix = this->debug_prefix_;
-  std::string:: debug_prefix = this->get_debug_settings_string() + this->debug_prefix_;
+  std::string debug_prefix = this->get_debug_settings_string() + this->debug_prefix_;
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_RX, data[i], debug_prefix);
   }

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -224,8 +224,10 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   uart_write_bytes(this->uart_num_, data, len);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
+  if (this->debug_add_settings_)
+    debug_prefix.insert(0, this->get_debug_settings_string());
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i]);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], debug_prefix);
   }
 #endif
 }
@@ -264,8 +266,11 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
     uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
+  std::string debug_prefix = this->debug_prefix_;
+  if (this->debug_add_settings_)
+    debug_prefix.insert(0, this->get_debug_settings_string());
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i]);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], debug_prefix);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -224,8 +224,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   uart_write_bytes(this->uart_num_, data, len);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
-  std::string:: debug_prefix = this->get_debug_settings_string(this->debug_add_settings_)
-                              + this->debug_prefix_;
+  std::string:: debug_prefix = this->get_debug_settings_string() + this->debug_prefix_;
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_TX, data[i], debug_prefix);
   }
@@ -267,8 +266,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   std::string debug_prefix = this->debug_prefix_;
-  std::string:: debug_prefix = this->get_debug_settings_string(this->debug_add_settings_)
-                              + this->debug_prefix_;
+  std::string:: debug_prefix = this->get_debug_settings_string() + this->debug_prefix_;
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_RX, data[i], debug_prefix);
   }

--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -213,7 +213,7 @@ void HostUartComponent::write_array(const uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
   return;
@@ -260,7 +260,7 @@ bool HostUartComponent::read_array(uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -213,7 +213,7 @@ void HostUartComponent::write_array(const uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], "");
   }
 #endif
   return;
@@ -260,7 +260,7 @@ bool HostUartComponent::read_array(uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], "");
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -119,7 +119,7 @@ void LibreTinyUARTComponent::write_array(const uint8_t *data, size_t len) {
   this->serial_->write(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
 }
@@ -137,7 +137,7 @@ bool LibreTinyUARTComponent::read_array(uint8_t *data, size_t len) {
   this->serial_->readBytes(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -119,7 +119,7 @@ void LibreTinyUARTComponent::write_array(const uint8_t *data, size_t len) {
   this->serial_->write(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], "");
   }
 #endif
 }
@@ -137,7 +137,7 @@ bool LibreTinyUARTComponent::read_array(uint8_t *data, size_t len) {
   this->serial_->readBytes(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], "");
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -151,7 +151,7 @@ void RP2040UartComponent::write_array(const uint8_t *data, size_t len) {
   this->serial_->write(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], "");
   }
 #endif
 }
@@ -167,7 +167,7 @@ bool RP2040UartComponent::read_array(uint8_t *data, size_t len) {
   this->serial_->readBytes(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], "");
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -151,7 +151,7 @@ void RP2040UartComponent::write_array(const uint8_t *data, size_t len) {
   this->serial_->write(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_);
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->get_debug_settings_string());
   }
 #endif
 }
@@ -167,7 +167,7 @@ bool RP2040UartComponent::read_array(uint8_t *data, size_t len) {
   this->serial_->readBytes(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_);
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->get_debug_settings_string());
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -151,7 +151,7 @@ void RP2040UartComponent::write_array(const uint8_t *data, size_t len) {
   this->serial_->write(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_TX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
 }
@@ -167,7 +167,7 @@ bool RP2040UartComponent::read_array(uint8_t *data, size_t len) {
   this->serial_->readBytes(data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
-    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->get_debug_settings_string());
+    this->debug_callback_.call(UART_DIRECTION_RX, data[i], this->debug_prefix_, this->debug_add_settings_);
   }
 #endif
   return true;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,9 +12,10 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
+  this->settings_string_ = parent->get_settings_string();
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (this->debug_add_settings_)
-      settings_string = this->get_debug_settings_string();
+      settings_string = this->settings_string_;
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -35,6 +35,10 @@ const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, 
 }
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
+  this->baud_rate_ = parent->get_baud_rate();
+  this->data_bits_ = parent->get_data_bits();
+  this->stop_bits_ = parent->get_stop_bits();
+  this->polarity_ = parent->get_polarity();
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,6 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  this->parent_ = parent;
   this->debug_settings_string = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,8 +13,7 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->parent_ = parent;
-  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
-    this->set_debug_prefix(debug_prefix);
+  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
@@ -77,7 +76,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
+  trigger(this->last_direction_, this->bytes_);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,6 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  parent->set_debug_add_settings(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -76,7 +76,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, this->debug_settings_string_);
+  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, this->debug_add_settings_);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -34,11 +34,11 @@ void UARTDebugger::loop() {
   this->trigger_after_timeout_();
 }
 
-void UARTDebugger::reload(UARTComponent* parent) {
-  this->baud_rate_ = parent->get_baud_rate();
-  this->data_bits_ = parent->get_data_bits();
-  this->stop_bits_ = parent->get_stop_bits();
-  this->parity_ = parent->get_parity();
+void UARTDebugger::reload() {
+  this->baud_rate_ = this->parent_->get_baud_rate();
+  this->data_bits_ = this->parent_->get_data_bits();
+  this->stop_bits_ = this->parent_->get_stop_bits();
+  this->parity_ = this->parent_->get_parity();
   this->debug_prefix_= get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
                                           this->data_bits_, this->stop_bits_, this->parity_);
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,14 +12,14 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string debug_settings) {
+  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
-    this->trigger_after_direction_change_(direction);
+    this->trigger_after_direction_change_(direction, settings_string);
     this->store_byte_(direction, byte);
-    this->trigger_after_delimiter_(byte);
-    this->trigger_after_bytes_();
+    this->trigger_after_delimiter_(byte, settings_string);
+    this->trigger_after_bytes_(settings_string);
   });
 }
 
@@ -31,10 +31,10 @@ bool UARTDebugger::is_my_direction_(UARTDirection direction) {
 
 bool UARTDebugger::is_recursive_() { return this->is_triggering_; }
 
-void UARTDebugger::trigger_after_direction_change_(UARTDirection direction) {
+void UARTDebugger::trigger_after_direction_change_(UARTDirection direction, std::string settings_string) {
   if (this->has_buffered_bytes_() && this->for_direction_ == UART_DIRECTION_BOTH &&
       this->last_direction_ != direction) {
-    this->fire_trigger_();
+    this->fire_trigger_(settings_string);
   }
 }
 
@@ -44,7 +44,7 @@ void UARTDebugger::store_byte_(UARTDirection direction, uint8_t byte) {
   this->last_time_ = millis();
 }
 
-void UARTDebugger::trigger_after_delimiter_(uint8_t byte) {
+void UARTDebugger::trigger_after_delimiter_(uint8_t byte, std::string settings_string) {
   if (this->after_delimiter_.empty() || !this->has_buffered_bytes_()) {
     return;
   }
@@ -54,33 +54,28 @@ void UARTDebugger::trigger_after_delimiter_(uint8_t byte) {
   }
   this->after_delimiter_pos_++;
   if (this->after_delimiter_pos_ == this->after_delimiter_.size()) {
-    this->fire_trigger_();
+    this->fire_trigger_(settings_string);
     this->after_delimiter_pos_ = 0;
   }
 }
 
-void UARTDebugger::trigger_after_bytes_() {
+void UARTDebugger::trigger_after_bytes_(, std::string settings_string) {
   if (this->has_buffered_bytes_() && this->after_bytes_ > 0 && this->bytes_.size() >= this->after_bytes_) {
-    this->fire_trigger_();
+    this->fire_trigger_(settings_string);
   }
 }
 
-void UARTDebugger::trigger_after_timeout_() {
+void UARTDebugger::trigger_after_timeout_(, std::string settings_string) {
   if (this->has_buffered_bytes_() && this->after_timeout_ > 0 && millis() - this->last_time_ >= this->after_timeout_) {
-    this->fire_trigger_();
+    this->fire_trigger_(settings_string);
   }
 }
 
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
-void UARTDebugger::fire_trigger_() {
+void UARTDebugger::fire_trigger_(std::string settings_string) {
   this->is_triggering_ = true;
-  if (this->debug_add_settings_) {
-    std::string settings_string = this->get_debug_settings_string();
-    trigger(this->last_direction_, this->bytes_, settings_string + this->debug_prefix_);
-  } else {
-    trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
-  }
+  trigger(this->last_direction_, this->bytes_, settings_string + this->debug_prefix_, settings_string);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,8 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  parent->set_debug_add_settings(this->debug_add_settings_);
-  this->debug_settings_string_ = parent->get_debug_settings_string();
+  this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
     std::string settings_string;
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -39,7 +39,7 @@ void UARTDebugger::reload() {
   this->data_bits_ = this->parent_->get_data_bits();
   this->stop_bits_ = this->parent_->get_stop_bits();
   this->parity_ = this->parent_->get_parity();
-  this->debug_prefix_ = get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
+  this->final_debug_prefix_ = get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
                                           this->data_bits_, this->stop_bits_, this->parity_);
 }
 

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -11,27 +11,27 @@ namespace uart {
 
 static const char *const TAG = "uart_debug";
 
-const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
+static std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
    if (!debug_add_settings)
-     return debug_prefix.c_str();
-   const char* res = "|" << baud_rate;
-   res << ":" << data_bits;
-   res << ":" << stop_bits;
+     return debug_prefix;
+   std::string res = "|" + baud_rate;
+   res += ":" + data_bits;
+   res += ":" + stop_bits;
    switch (parity) {
      case UART_CONFIG_PARITY_NONE:
-       res << "NONE";
+       res += "NONE";
        break;
      case UART_CONFIG_PARITY_EVEN:
-       res << "EVEN";
+       res += "EVEN";
        break;
      case UART_CONFIG_PARITY_ODD:
-       res << "ODD";
+       res += "ODD";
        break;
    default:
-     res << "UNKNOWN";
+     res += "UNKNOWN";
      break;
    }
-   return res << "|" << debug_prefix.c_str();
+   return res + "|" + debug_prefix;
 }
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -28,10 +28,10 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
   });
 }
 
-void UARTDebugger::loop() { 
-  this->trigger_after_timeout_();
+void UARTDebugger::loop() {
   if (this->parent_->debugger_needs_reload())
     this->reload();
+  this->trigger_after_timeout_();
 }
 
 void UARTDebugger::reload(UARTComponent* parent) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,7 +14,7 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->parent_ = parent;
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
-    this->debug_prefix_ = debug_prefix;
+    this->set_debug_prefix(debug_prefix);
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -21,6 +21,7 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
     this->trigger_after_delimiter_(byte, settings_string);
     this->trigger_after_bytes_(settings_string);
   });
+  parent->set_debug_add_settings(this->debug_add_settings_);
 }
 
 void UARTDebugger::loop() { this->trigger_after_timeout_(); }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -30,6 +30,14 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
 
 void UARTDebugger::loop() { this->trigger_after_timeout_(); }
 
+void UARTDebugger::reload(UARTComponent* parent) {
+  parent->set_debugger(this);
+  this->baud_rate_ = parent->get_baud_rate();
+  this->data_bits_ = parent->get_data_bits();
+  this->stop_bits_ = parent->get_stop_bits();
+  this->parity_ = parent->get_parity();
+}
+
 bool UARTDebugger::is_my_direction_(UARTDirection direction) {
   return this->for_direction_ == UART_DIRECTION_BOTH || this->for_direction_ == direction;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -55,7 +55,7 @@ void UARTDebugger::trigger_after_delimiter_(uint8_t byte, std::string settings_s
   }
   this->after_delimiter_pos_++;
   if (this->after_delimiter_pos_ == this->after_delimiter_.size()) {
-    this->fire_trigger_(settings_string);
+    this->fire_trigger_();
     this->after_delimiter_pos_ = 0;
   }
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -11,17 +11,17 @@ namespace uart {
 
 static const char *const TAG = "uart_debug";
 
-UARTDebugger::UARTDebugger(UARTComponent *parent, bool debug_add_settings) {
+UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->debug_add_settings_ = debug_add_settings;
   this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
-    this->trigger_after_direction_change_(direction, true);
+    this->trigger_after_direction_change_(direction);
     this->store_byte_(direction, byte);
-    this->trigger_after_delimiter_(byte, true);
-    this->trigger_after_bytes_(true);
+    this->trigger_after_delimiter_(byte);
+    this->trigger_after_bytes_();
   });
 }
 
@@ -33,10 +33,10 @@ bool UARTDebugger::is_my_direction_(UARTDirection direction) {
 
 bool UARTDebugger::is_recursive_() { return this->is_triggering_; }
 
-void UARTDebugger::trigger_after_direction_change_(UARTDirection direction, bool debug_add_settings) {
+void UARTDebugger::trigger_after_direction_change_(UARTDirection direction) {
   if (this->has_buffered_bytes_() && this->for_direction_ == UART_DIRECTION_BOTH &&
       this->last_direction_ != direction) {
-    this->fire_trigger_(debug_add_settings);
+    this->fire_trigger_();
   }
 }
 
@@ -46,7 +46,7 @@ void UARTDebugger::store_byte_(UARTDirection direction, uint8_t byte) {
   this->last_time_ = millis();
 }
 
-void UARTDebugger::trigger_after_delimiter_(uint8_t byte, bool debug_add_settings) {
+void UARTDebugger::trigger_after_delimiter_(uint8_t byte) {
   if (this->after_delimiter_.empty() || !this->has_buffered_bytes_()) {
     return;
   }
@@ -56,28 +56,28 @@ void UARTDebugger::trigger_after_delimiter_(uint8_t byte, bool debug_add_setting
   }
   this->after_delimiter_pos_++;
   if (this->after_delimiter_pos_ == this->after_delimiter_.size()) {
-    this->fire_trigger_(debug_add_settings);
+    this->fire_trigger_();
     this->after_delimiter_pos_ = 0;
   }
 }
 
-void UARTDebugger::trigger_after_bytes_(bool debug_add_settings) {
+void UARTDebugger::trigger_after_bytes_() {
   if (this->has_buffered_bytes_() && this->after_bytes_ > 0 && this->bytes_.size() >= this->after_bytes_) {
-    this->fire_trigger_(debug_add_settings);
+    this->fire_trigger_();
   }
 }
 
-void UARTDebugger::trigger_after_timeout_(bool debug_add_settings) {
+void UARTDebugger::trigger_after_timeout_() {
   if (this->has_buffered_bytes_() && this->after_timeout_ > 0 && millis() - this->last_time_ >= this->after_timeout_) {
-    this->fire_trigger_(debug_add_settings);
+    this->fire_trigger_();
   }
 }
 
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
-void UARTDebugger::fire_trigger_(bool debug_add_settings) {
+void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, this->debug_settings_string_);
+  trigger(this->last_direction_, this->bytes_);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }
@@ -97,7 +97,7 @@ void UARTDummyReceiver::loop() {
 // TCP connection(s). Without these delays, debug log lines could go
 // missing when UART devices block the main loop for too long.
 
-void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix, std::string settings_string) {
+void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator) {
   std::string res;
   if (direction == UART_DIRECTION_RX) {
     res += "<<< ";
@@ -113,17 +113,10 @@ void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uin
     sprintf(buf, "%02X", bytes[i]);
     res += buf;
   }
-  if(!debug_prefix.empty() && !settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
-  } else if (!debug_prefix.empty() && settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
-  } else {
-    ESP_LOGD(TAG, "%s", res.c_str());
-  }
-  delay(10);
+  ESP_LOGD(TAG, "%s", res.c_str());
 }
 
-void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes, std::string debug_prefix, std::string settings_string) {
+void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes) {
   std::string res;
   if (direction == UART_DIRECTION_RX) {
     res += "<<< \"";
@@ -163,17 +156,11 @@ void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes, 
     }
   }
   res += '"';
-  if(!debug_prefix.empty() && !settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
-  } else if (!debug_prefix.empty() && settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
-  } else {
-    ESP_LOGD(TAG, "%s", res.c_str());
-  }
+  ESP_LOGD(TAG, "%s", res.c_str());
   delay(10);
 }
 
-void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix, std::string settings_string) {
+void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator) {
   std::string res;
   size_t len = bytes.size();
   if (direction == UART_DIRECTION_RX) {
@@ -187,17 +174,11 @@ void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uin
     }
     res += to_string(bytes[i]);
   }
-  if(!debug_prefix.empty() && !settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
-  } else if (!debug_prefix.empty() && settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
-  } else {
-    ESP_LOGD(TAG, "%s", res.c_str());
-  }
+  ESP_LOGD(TAG, "%s", res.c_str());
   delay(10);
 }
 
-void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix, std::string settings_string) {
+void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator) {
   std::string res;
   size_t len = bytes.size();
   if (direction == UART_DIRECTION_RX) {
@@ -213,13 +194,7 @@ void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, 
     sprintf(buf, "0b" BYTE_TO_BINARY_PATTERN " (0x%02X)", BYTE_TO_BINARY(bytes[i]), bytes[i]);
     res += buf;
   }
-  if(!debug_prefix.empty() && !settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
-  } else if (!debug_prefix.empty() && settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
-  } else {
-    ESP_LOGD(TAG, "%s", res.c_str());
-  }
+  ESP_LOGD(TAG, "%s", res.c_str());
   delay(10);
 }
 

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -43,9 +43,6 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
-    this->debug_prefix_= get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
-                                          this->data_bits_, this->stop_bits_, this->parity_);
-    this->trigger_after_direction_change_(direction);
     this->store_byte_(direction, byte);
     this->trigger_after_delimiter_(byte);
     this->trigger_after_bytes_();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_prefix_, this->debug_add_settings_);
+  this->debug_settings_string_ = parent->get_debug_prefix(this->debug_prefix_, this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
-    if (this->add_debug_settings_)
+    if (this->debug_add_settings_)
       settings_string = this->get_debug_settings_string();
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -11,7 +11,8 @@ namespace uart {
 
 static const char *const TAG = "uart_debug";
 
-UARTDebugger::UARTDebugger(UARTComponent *parent) {
+UARTDebugger::UARTDebugger(UARTComponent *parent, bool debug_add_settings) {
+  this->debug_add_settings_ = debug_add_settings;
   this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,24 +14,24 @@ static const char *const TAG = "uart_debug";
 const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
    if (!debug_add_settings)
      return debug_prefix.c_str();
-   const char* res = "|" + baud_rate;
-   res += ":" + data_bits;
-   res += ":" + stop_bits;
+   const char* res = "|" << baud_rate;
+   res << ":" << data_bits;
+   res << ":" << stop_bits;
    switch (parity) {
      case UART_CONFIG_PARITY_NONE:
-       res &= "NONE";
+       res << "NONE";
        break;
      case UART_CONFIG_PARITY_EVEN:
-       res &= "EVEN";
+       res << "EVEN";
        break;
      case UART_CONFIG_PARITY_ODD:
-       res &= "ODD";
+       res << "ODD";
        break;
    default:
-     res += "UNKNOWN";
+     res << "UNKNOWN";
      break;
    }
-   return res + "|" + debug_prefix.c_str();
+   return res << "|" << debug_prefix.c_str();
 }
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->parent_ = parent;
-  this->debug_settings_str = parent->get_debug_settings_string(this->debug_add_settings_);
+  this->debug_settings_string = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -39,7 +39,7 @@ void UARTDebugger::reload() {
   this->data_bits_ = this->parent_->get_data_bits();
   this->stop_bits_ = this->parent_->get_stop_bits();
   this->parity_ = this->parent_->get_parity();
-  this->debug_prefix_= get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
+  this->debug_prefix_ = get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
                                           this->data_bits_, this->stop_bits_, this->parity_);
 }
 

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -75,7 +75,7 @@ void UARTDebugger::trigger_after_timeout_() {
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 std::string UARTDebugger::get_debug_prefix() {
-  if (!this->debug_add_prefix_)
+  if (!this->debug_add_settings_)
     return this->debug_prefix_;
   std::string res = "|" + this->parent_->get_baud_rate();
   res += ":" + this->parent_->get_data_bits();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -75,7 +75,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_(std::string settings_string) {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, settings_string + this->debug_prefix_, settings_string);
+  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, settings_string);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -80,7 +80,7 @@ std::string UARTDebugger::get_debug_prefix() {
   std::string res = "|" + this->parent_->get_baud_rate();
   res += ":" + this->parent_->get_data_bits();
   res += ":" + this->parent_->get_stop_bits();
-  res += ":" + esphome::uart::parity_to_str(this->parent_->get_parity());
+  res += ":" + static_cast<std::string>(esphome::uart::parity_to_str(this->parent_->get_parity()));
   return res + this->debug_prefix_;
 }
 

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->parent_ = parent;
-  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
+  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -74,6 +74,7 @@ void UARTDebugger::trigger_after_timeout_() {
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
+  this->debug_prefix_= this->parent_->get_debug_prefix(this->debug_prefix_, debug_add_settings);
   this->is_triggering_ = true;
   trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
   this->bytes_.clear();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -74,7 +74,7 @@ void UARTDebugger::trigger_after_timeout_() {
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
-  this->debug_prefix_= this->parent_->get_debug_prefix(this->debug_prefix_, debug_add_settings);
+  this->debug_prefix_= this->parent_->get_debug_prefix(this->debug_prefix_, this->debug_add_settings_);
   this->is_triggering_ = true;
   trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
   this->bytes_.clear();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -16,6 +16,8 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
+    this->debug_prefix_= get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
+                                          this->data_bits_, this->stop_bits_, this->polarity_);
     this->trigger_after_direction_change_(direction);
     this->store_byte_(direction, byte);
     this->trigger_after_delimiter_(byte);
@@ -73,13 +75,13 @@ void UARTDebugger::trigger_after_timeout_() {
 
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
-std::string UARTDebugger::get_debug_prefix(std::string debug_prefix, bool debug_add_settings) {
+const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t polarity) {
    if (!debug_add_settings)
      return debug_prefix;
-   std::string res = "|" + this->parent_->get_baud_rate();
-   res += ":" + this->parent_->get_data_bits();
-   res += ":" + this->parent_->get_stop_bits();
-   switch (this->parent_->get_parity()) {
+   std::string res = "|" + baud_rate;
+   res += ":" + data_bits;
+   res += ":" + stop_bits;
+   switch (parity) {
      case UART_CONFIG_PARITY_NONE:
        res += "NONE";
        break;
@@ -97,7 +99,6 @@ std::string UARTDebugger::get_debug_prefix(std::string debug_prefix, bool debug_
 }
 
 void UARTDebugger::fire_trigger_() {
-  this->debug_prefix_= this->get_debug_prefix(this->debug_prefix_, this->debug_add_settings_);
   this->is_triggering_ = true;
   trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
   this->bytes_.clear();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,6 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  this->debug_settings_string_ = parent->get_debug_prefix(this->debug_prefix_, this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
-  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte) {
+  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
@@ -96,7 +96,7 @@ void UARTDummyReceiver::loop() {
 // TCP connection(s). Without these delays, debug log lines could go
 // missing when UART devices block the main loop for too long.
 
-void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator) {
+void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix) {
   std::string res;
   if (direction == UART_DIRECTION_RX) {
     res += "<<< ";
@@ -115,7 +115,7 @@ void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uin
   ESP_LOGD(TAG, "%s", res.c_str());
 }
 
-void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes) {
+void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes, std::string debug_prefix) {
   std::string res;
   if (direction == UART_DIRECTION_RX) {
     res += "<<< \"";
@@ -159,7 +159,7 @@ void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes) 
   delay(10);
 }
 
-void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator) {
+void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix) {
   std::string res;
   size_t len = bytes.size();
   if (direction == UART_DIRECTION_RX) {
@@ -177,7 +177,7 @@ void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uin
   delay(10);
 }
 
-void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator) {
+void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix) {
   std::string res;
   size_t len = bytes.size();
   if (direction == UART_DIRECTION_RX) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,6 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
+  this->parent_ = parent;
   this->baud_rate_ = parent->get_baud_rate();
   this->data_bits_ = parent->get_data_bits();
   this->stop_bits_ = parent->get_stop_bits();
@@ -27,10 +28,13 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
   });
 }
 
-void UARTDebugger::loop() { this->trigger_after_timeout_(); }
+void UARTDebugger::loop() { 
+  this->trigger_after_timeout_();
+  if (this->parent_->debugger_needs_reload())
+    this->reload();
+}
 
 void UARTDebugger::reload(UARTComponent* parent) {
-  parent->set_debugger(this);
   this->baud_rate_ = parent->get_baud_rate();
   this->data_bits_ = parent->get_data_bits();
   this->stop_bits_ = parent->get_stop_bits();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -74,16 +74,6 @@ void UARTDebugger::trigger_after_timeout_() {
 
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
-std::string UARTDebugger::get_debug_prefix() {
-  if (!this->debug_add_settings_)
-    return this->debug_prefix_;
-  std::string res = "|" + this->parent_->get_baud_rate();
-  res += ":" + this->parent_->get_data_bits();
-  res += ":" + this->parent_->get_stop_bits();
-  //res += ":" + static_cast<std::string>(esphome::uart::parity_to_str(this->parent_->get_parity()));
-  return res + this->debug_prefix_;
-}
-
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
   trigger(this->last_direction_, this->bytes_, this->get_debug_prefix());

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -78,19 +78,9 @@ std::string UARTDebugger::get_debug_prefix() {
   if (!this->debug_add_prefix_)
     return this->debug_prefix_;
   std::string res = "|" + this->parent_->get_baud_rate();
-  res + = ":" + this->parent_->get_data_bits();
-  res + = ":" + this->parent_->get_stop_bits();
-  switch(this->parent_->get_polarity()) {
-    case 0:
-      res + = "none|";
-      break;
-    case 1:
-      res + = "even|";
-      break;
-    case 2:
-      res + = "odd|";
-      break;
-  }
+  res += ":" + this->parent_->get_data_bits();
+  res += ":" + this->parent_->get_stop_bits();
+  res += ":" + (reinterpret_cast<std::string>(*esphome::uart::parity_to_str(this->parent_->get_parity()));
   return res + this->debug_prefix_;
 }
 

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  this->debug_settings_string = parent->get_debug_settings_string(this->debug_add_settings_);
+  this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,7 +14,7 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent, bool debug_add_settings) {
   this->debug_add_settings_ = debug_add_settings;
   this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
-  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
+  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string debug_add_settings) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
@@ -77,7 +77,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_(bool debug_add_settings) {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, debug_add_settings);
+  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, this->debug_settings_string_);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -73,8 +73,31 @@ void UARTDebugger::trigger_after_timeout_() {
 
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
+std::string UARTDebugger::get_debug_prefix(std::string debug_prefix, bool debug_add_settings) {
+   if (!debug_add_settings)
+     return debug_prefix;
+   std::string res = "|" + this->baud_rate_;
+   res += ":" + this->parent_->get_data_bits();
+   res += ":" + this->parent_->get_stop_bits();
+   switch (this->parent_->get_parity()) {
+     case UART_CONFIG_PARITY_NONE:
+       res += "NONE";
+       break;
+     case UART_CONFIG_PARITY_EVEN:
+       res += "EVEN";
+       break;
+     case UART_CONFIG_PARITY_ODD:
+       res += "ODD";
+       break;
+   default:
+     res += "UNKNOWN";
+     break;
+   }
+   return res + "|" + debug_prefix;
+}
+
 void UARTDebugger::fire_trigger_() {
-  this->debug_prefix_= this->parent_->get_debug_prefix(this->debug_prefix_, this->debug_add_settings_);
+  this->debug_prefix_= this->get_debug_prefix(this->debug_prefix_, this->debug_add_settings_);
   this->is_triggering_ = true;
   trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
   this->bytes_.clear();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -16,7 +16,7 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
     std::string settings_string;
     if (debug_add_settings_)
-      settings_string = this->settings_string_;
+      settings_string = this->get_debug_settings_string();
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -112,7 +112,7 @@ void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uin
     res += buf;
   }
   if(!debug_prefix.empty() && !settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s%s", debug_prefix.c_str(), settings_string.c_str(), res.c_str());
+    ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
   } else if (!debug_prefix.empty()) {
     ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
   } else {
@@ -162,7 +162,7 @@ void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes, 
   }
   res += '"';
   if(!debug_prefix.empty() && !settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s%s", debug_prefix.c_str(), settings_string.c_str(), res.c_str());
+    ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
   } else if (!debug_prefix.empty()) {
     ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
   } else {
@@ -186,7 +186,7 @@ void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uin
     res += to_string(bytes[i]);
   }
   if(!debug_prefix.empty() && !settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s%s", debug_prefix.c_str(), settings_string.c_str(), res.c_str());
+    ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
   } else if (!debug_prefix.empty()) {
     ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
   } else {
@@ -212,7 +212,7 @@ void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, 
     res += buf;
   }
   if(!debug_prefix.empty() && !settings_string.empty()) {
-    ESP_LOGD(TAG, "%s%s%s", debug_prefix.c_str(), settings_string.c_str(), res.c_str());
+    ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
   } else if (!debug_prefix.empty()) {
     ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
   } else {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,7 +14,7 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent, bool debug_add_settings) {
   this->debug_add_settings_ = debug_add_settings;
   this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
-  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string debug_add_settings) {
+  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,7 +14,7 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (this->debug_add_settings_)
-      settings_string = this->->get_debug_settings_string();
+      settings_string = this->get_debug_settings_string();
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,7 +14,7 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (this->debug_add_settings_)
-      settings_string = this->get_debug_settings_string();
+      settings_string = this->parent_->get_debug_settings_string();
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,6 +13,7 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->parent_ = parent;
+  this->debug_settings_str = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
@@ -76,7 +77,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, this->get_debug_prefix());
+  trigger(this->last_direction_, this->bytes_, this->debug_settings_string_);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,7 +14,6 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
-    std::string settings_string;
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -80,7 +80,7 @@ std::string UARTDebugger::get_debug_prefix() {
   std::string res = "|" + this->parent_->get_baud_rate();
   res += ":" + this->parent_->get_data_bits();
   res += ":" + this->parent_->get_stop_bits();
-  res += ":" + (reinterpret_cast<std::string>(*esphome::uart::parity_to_str(this->parent_->get_parity()));
+  res += ":" + esphome::uart::parity_to_str(this->parent_->get_parity());
   return res + this->debug_prefix_;
 }
 

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,9 +12,9 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  this->settings_string_ = parent->get_debug_settings_string();
-  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
-    if (this->debug_add_settings_)
+  parent_->settings_string_ = parent->get_debug_settings_string();
+  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
+    if (debug_add_settings_)
       settings_string = this->settings_string_;
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -11,6 +11,29 @@ namespace uart {
 
 static const char *const TAG = "uart_debug";
 
+const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t polarity) {
+   if (!debug_add_settings)
+     return debug_prefix;
+   std::string res = "|" + baud_rate;
+   res += ":" + data_bits;
+   res += ":" + stop_bits;
+   switch (parity) {
+     case UART_CONFIG_PARITY_NONE:
+       res += "NONE";
+       break;
+     case UART_CONFIG_PARITY_EVEN:
+       res += "EVEN";
+       break;
+     case UART_CONFIG_PARITY_ODD:
+       res += "ODD";
+       break;
+   default:
+     res += "UNKNOWN";
+     break;
+   }
+   return res + "|" + debug_prefix;
+}
+
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
@@ -74,29 +97,6 @@ void UARTDebugger::trigger_after_timeout_() {
 }
 
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
-
-const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t polarity) {
-   if (!debug_add_settings)
-     return debug_prefix;
-   std::string res = "|" + baud_rate;
-   res += ":" + data_bits;
-   res += ":" + stop_bits;
-   switch (parity) {
-     case UART_CONFIG_PARITY_NONE:
-       res += "NONE";
-       break;
-     case UART_CONFIG_PARITY_EVEN:
-       res += "EVEN";
-       break;
-     case UART_CONFIG_PARITY_ODD:
-       res += "ODD";
-       break;
-   default:
-     res += "UNKNOWN";
-     break;
-   }
-   return res + "|" + debug_prefix;
-}
 
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,7 +14,7 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (this->debug_add_settings_)
-      settings_string = parent_->get_debug_settings_string();
+      settings_string = parent->get_debug_settings_string();
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->parent_ = parent;
-  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte) {
+  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -111,7 +111,7 @@ void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uin
     sprintf(buf, "%02X", bytes[i]);
     res += buf;
   }
-  ESP_LOGD(TAG, "%s", res.c_str());
+  ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(),res.c_str());
 }
 
 void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes, std::string debug_prefix) {
@@ -154,7 +154,7 @@ void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes, 
     }
   }
   res += '"';
-  ESP_LOGD(TAG, "%s", res.c_str());
+  ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(),res.c_str());
   delay(10);
 }
 
@@ -172,7 +172,7 @@ void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uin
     }
     res += to_string(bytes[i]);
   }
-  ESP_LOGD(TAG, "%s", res.c_str());
+  ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(),res.c_str());
   delay(10);
 }
 
@@ -192,7 +192,7 @@ void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, 
     sprintf(buf, "0b" BYTE_TO_BINARY_PATTERN " (0x%02X)", BYTE_TO_BINARY(bytes[i]), bytes[i]);
     res += buf;
   }
-  ESP_LOGD(TAG, "%s", res.c_str());
+  ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(),res.c_str());
   delay(10);
 }
 

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -16,15 +16,13 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->debug_settings_string_ = parent->get_debug_settings_string();
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
     std::string settings_string;
-    if (debug_add_settings_)
-      settings_string = this->debug_settings_string_;
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
-    this->trigger_after_direction_change_(direction, settings_string);
+    this->trigger_after_direction_change_(direction);
     this->store_byte_(direction, byte);
-    this->trigger_after_delimiter_(byte, settings_string);
-    this->trigger_after_bytes_(settings_string);
+    this->trigger_after_delimiter_(byte);
+    this->trigger_after_bytes_();
   });
 }
 
@@ -39,7 +37,7 @@ bool UARTDebugger::is_recursive_() { return this->is_triggering_; }
 void UARTDebugger::trigger_after_direction_change_(UARTDirection direction, std::string settings_string) {
   if (this->has_buffered_bytes_() && this->for_direction_ == UART_DIRECTION_BOTH &&
       this->last_direction_ != direction) {
-    this->fire_trigger_(settings_string);
+    this->fire_trigger_();
   }
 }
 
@@ -66,21 +64,21 @@ void UARTDebugger::trigger_after_delimiter_(uint8_t byte, std::string settings_s
 
 void UARTDebugger::trigger_after_bytes_(std::string settings_string) {
   if (this->has_buffered_bytes_() && this->after_bytes_ > 0 && this->bytes_.size() >= this->after_bytes_) {
-    this->fire_trigger_(settings_string);
+    this->fire_trigger_();
   }
 }
 
 void UARTDebugger::trigger_after_timeout_(std::string settings_string) {
   if (this->has_buffered_bytes_() && this->after_timeout_ > 0 && millis() - this->last_time_ >= this->after_timeout_) {
-    this->fire_trigger_(settings_string);
+    this->fire_trigger_();
   }
 }
 
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
-void UARTDebugger::fire_trigger_(std::string settings_string) {
+void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, settings_string);
+  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, this->debug_settings_string_);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,10 +13,11 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->set_debug_add_settings(this->debug_add_settings_);
+  this->debug_settings_string_ = parent->get_debug_settings_string();
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
     std::string settings_string;
     if (debug_add_settings_)
-      settings_string = this->get_debug_settings_string();
+      settings_string = this->debug_settings_string_;
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -36,6 +36,8 @@ void UARTDebugger::reload(UARTComponent* parent) {
   this->data_bits_ = parent->get_data_bits();
   this->stop_bits_ = parent->get_stop_bits();
   this->parity_ = parent->get_parity();
+  this->debug_prefix_= get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
+                                          this->data_bits_, this->stop_bits_, this->parity_);
 }
 
 bool UARTDebugger::is_my_direction_(UARTDirection direction) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -11,29 +11,6 @@ namespace uart {
 
 static const char *const TAG = "uart_debug";
 
-static std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
-   if (!debug_add_settings)
-     return debug_prefix;
-   std::string res = "|" + baud_rate;
-   res += ":" + data_bits;
-   res += ":" + stop_bits;
-   switch (parity) {
-     case UART_CONFIG_PARITY_NONE:
-       res += "NONE";
-       break;
-     case UART_CONFIG_PARITY_EVEN:
-       res += "EVEN";
-       break;
-     case UART_CONFIG_PARITY_ODD:
-       res += "ODD";
-       break;
-   default:
-     res += "UNKNOWN";
-     break;
-   }
-   return res + "|" + debug_prefix;
-}
-
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->baud_rate_ = parent->get_baud_rate();
   this->data_bits_ = parent->get_data_bits();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -80,7 +80,7 @@ std::string UARTDebugger::get_debug_prefix() {
   std::string res = "|" + this->parent_->get_baud_rate();
   res += ":" + this->parent_->get_data_bits();
   res += ":" + this->parent_->get_stop_bits();
-  res += ":" + static_cast<std::string>(esphome::uart::parity_to_str(this->parent_->get_parity()));
+  //res += ":" + static_cast<std::string>(esphome::uart::parity_to_str(this->parent_->get_parity()));
   return res + this->debug_prefix_;
 }
 

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -11,7 +11,7 @@ namespace uart {
 
 static const char *const TAG = "uart_debug";
 
-const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t polarity) {
+const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
    if (!debug_add_settings)
      return debug_prefix;
    std::string res = "|" + baud_rate;
@@ -38,13 +38,13 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->baud_rate_ = parent->get_baud_rate();
   this->data_bits_ = parent->get_data_bits();
   this->stop_bits_ = parent->get_stop_bits();
-  this->polarity_ = parent->get_polarity();
+  this->parity_ = parent->get_parity();
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
     this->debug_prefix_= get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
-                                          this->data_bits_, this->stop_bits_, this->polarity_);
+                                          this->data_bits_, this->stop_bits_, this->parity_);
     this->trigger_after_direction_change_(direction);
     this->store_byte_(direction, byte);
     this->trigger_after_delimiter_(byte);

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,7 +14,7 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (this->debug_add_settings_)
-      settings_string = parent->get_debug_settings_string();
+      settings_string = this->->get_debug_settings_string();
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,6 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
+  parent->set_debugger(this);
   this->baud_rate_ = parent->get_baud_rate();
   this->data_bits_ = parent->get_data_bits();
   this->stop_bits_ = parent->get_stop_bits();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,6 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  this->debug_add_settings_ = debug_add_settings;
   this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,11 +12,13 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
+#ifdef UART_DEBUGGER_ADD_SETTINGS
   this->parent_ = parent;
   this->baud_rate_ = parent->get_baud_rate();
   this->data_bits_ = parent->get_data_bits();
   this->stop_bits_ = parent->get_stop_bits();
   this->parity_ = parent->get_parity();
+#endif
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
@@ -29,11 +31,14 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
 }
 
 void UARTDebugger::loop() {
-  if (this->debug_add_settings_ && this->parent_->debugger_needs_reload())
+#ifdef UART_DEBUGGER_ADD_SETTINGS
+  if (this->parent_->debugger_needs_reload())
     this->reload();
+#endif
   this->trigger_after_timeout_();
 }
 
+#ifdef UART_DEBUGGER_ADD_SETTINGS
 void UARTDebugger::reload() {
   this->baud_rate_ = this->parent_->get_baud_rate();
   this->data_bits_ = this->parent_->get_data_bits();
@@ -42,6 +47,7 @@ void UARTDebugger::reload() {
   this->final_debug_prefix_ = get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
                                           this->data_bits_, this->stop_bits_, this->parity_);
 }
+#endif
 
 bool UARTDebugger::is_my_direction_(UARTDirection direction) {
   return this->for_direction_ == UART_DIRECTION_BOTH || this->for_direction_ == direction;
@@ -93,7 +99,11 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
+#ifdef UART_DEBUGGER_ADD_SETTINGS
   trigger(this->last_direction_, this->bytes_, this->final_debug_prefix_);
+#else
+  trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
+#endif
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -115,7 +115,7 @@ void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uin
   }
   if(!debug_prefix.empty() && !settings_string.empty()) {
     ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
-  } else if (!debug_prefix.empty()) {
+  } else if (!debug_prefix.empty() && settings_string.empty()) {
     ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
   } else {
     ESP_LOGD(TAG, "%s", res.c_str());
@@ -165,7 +165,7 @@ void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes, 
   res += '"';
   if(!debug_prefix.empty() && !settings_string.empty()) {
     ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
-  } else if (!debug_prefix.empty()) {
+  } else if (!debug_prefix.empty() && settings_string.empty()) {
     ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
   } else {
     ESP_LOGD(TAG, "%s", res.c_str());
@@ -189,7 +189,7 @@ void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uin
   }
   if(!debug_prefix.empty() && !settings_string.empty()) {
     ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
-  } else if (!debug_prefix.empty()) {
+  } else if (!debug_prefix.empty() && settings_string.empty()) {
     ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
   } else {
     ESP_LOGD(TAG, "%s", res.c_str());
@@ -215,7 +215,7 @@ void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, 
   }
   if(!debug_prefix.empty() && !settings_string.empty()) {
     ESP_LOGD(TAG, "%s%s%s", settings_string.c_str(), debug_prefix.c_str(), res.c_str());
-  } else if (!debug_prefix.empty()) {
+  } else if (!debug_prefix.empty() && settings_string.empty()) {
     ESP_LOGD(TAG, "%s%s", debug_prefix.c_str(), res.c_str());
   } else {
     ESP_LOGD(TAG, "%s", res.c_str());

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,6 +13,8 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
+    if (this->add_debug_settings_)
+      settings_string = this->get_debug_settings_string();
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
+  this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_prefix_, this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -59,13 +59,13 @@ void UARTDebugger::trigger_after_delimiter_(uint8_t byte, std::string settings_s
   }
 }
 
-void UARTDebugger::trigger_after_bytes_(, std::string settings_string) {
+void UARTDebugger::trigger_after_bytes_(std::string settings_string) {
   if (this->has_buffered_bytes_() && this->after_bytes_ > 0 && this->bytes_.size() >= this->after_bytes_) {
     this->fire_trigger_(settings_string);
   }
 }
 
-void UARTDebugger::trigger_after_timeout_(, std::string settings_string) {
+void UARTDebugger::trigger_after_timeout_(std::string settings_string) {
   if (this->has_buffered_bytes_() && this->after_timeout_ > 0 && millis() - this->last_time_ >= this->after_timeout_) {
     this->fire_trigger_(settings_string);
   }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,6 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
+  this->parent_ = parent;
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     this->debug_prefix_ = debug_prefix;
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -19,13 +19,13 @@ const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, 
    res += ":" + stop_bits;
    switch (parity) {
      case UART_CONFIG_PARITY_NONE:
-       res += "NONE";
+       res &= "NONE";
        break;
      case UART_CONFIG_PARITY_EVEN:
-       res += "EVEN";
+       res &= "EVEN";
        break;
      case UART_CONFIG_PARITY_ODD:
-       res += "ODD";
+       res &= "ODD";
        break;
    default:
      res += "UNKNOWN";

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,6 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
+  parent->set_debug_add_settings(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
@@ -21,7 +22,6 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
     this->trigger_after_delimiter_(byte, settings_string);
     this->trigger_after_bytes_(settings_string);
   });
-  parent->set_debug_add_settings(this->debug_add_settings_);
 }
 
 void UARTDebugger::loop() { this->trigger_after_timeout_(); }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  parent_->settings_string_ = parent->get_debug_settings_string();
+  parent->set_debug_settings_string();
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
     if (debug_add_settings_)
       settings_string = this->settings_string_;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,13 +12,6 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-  this->parent_ = parent;
-  this->baud_rate_ = parent->get_baud_rate();
-  this->data_bits_ = parent->get_data_bits();
-  this->stop_bits_ = parent->get_stop_bits();
-  this->parity_ = parent->get_parity();
-#endif
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
@@ -30,24 +23,7 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
   });
 }
 
-void UARTDebugger::loop() {
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-  if (this->parent_->debugger_needs_reload())
-    this->reload();
-#endif
-  this->trigger_after_timeout_();
-}
-
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-void UARTDebugger::reload() {
-  this->baud_rate_ = this->parent_->get_baud_rate();
-  this->data_bits_ = this->parent_->get_data_bits();
-  this->stop_bits_ = this->parent_->get_stop_bits();
-  this->parity_ = this->parent_->get_parity();
-  this->final_debug_prefix_ = get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
-                                          this->data_bits_, this->stop_bits_, this->parity_);
-}
-#endif
+void UARTDebugger::loop() { this->trigger_after_timeout_(); }
 
 bool UARTDebugger::is_my_direction_(UARTDirection direction) {
   return this->for_direction_ == UART_DIRECTION_BOTH || this->for_direction_ == direction;
@@ -99,11 +75,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-  trigger(this->last_direction_, this->bytes_, this->final_debug_prefix_);
-#else
   trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
-#endif
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   this->parent_ = parent;
-  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte) {
+  parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
@@ -74,9 +74,29 @@ void UARTDebugger::trigger_after_timeout_() {
 
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
+std::string UARTDebugger::get_debug_prefix() {
+  if (!this->debug_add_prefix_)
+    return this->debug_prefix_;
+  std::string res = "|" + this->parent_->get_baud_rate();
+  res + = ":" + this->parent_->get_data_bits();
+  res + = ":" + this->parent_->get_stop_bits();
+  switch(this->parent_->get_polarity()) {
+    case 0:
+      res + = "none|";
+      break;
+    case 1:
+      res + = "even|";
+      break;
+    case 2:
+      res + = "odd|";
+      break;
+  }
+  return res + this->debug_prefix_;
+}
+
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_);
+  trigger(this->last_direction_, this->bytes_, this->get_debug_prefix());
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,8 +13,8 @@ static const char *const TAG = "uart_debug";
 
 const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
    if (!debug_add_settings)
-     return debug_prefix;
-   std::string res = "|" + baud_rate;
+     return debug_prefix.c_str();
+   const char* res = "|" + baud_rate;
    res += ":" + data_bits;
    res += ":" + stop_bits;
    switch (parity) {
@@ -31,7 +31,7 @@ const char* get_debug_prefix(std::string debug_prefix, bool debug_add_settings, 
      res += "UNKNOWN";
      break;
    }
-   return res + "|" + debug_prefix;
+   return res + "|" + debug_prefix.c_str();
 }
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -13,6 +13,7 @@ static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
+    this->debug_prefix_ = debug_prefix;
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
@@ -75,7 +76,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_);
+  trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,6 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  this->debug_settings_string_ = parent->get_debug_settings_string(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,6 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  parent->set_debugger(this);
   this->baud_rate_ = parent->get_baud_rate();
   this->data_bits_ = parent->get_data_bits();
   this->stop_bits_ = parent->get_stop_bits();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  parent->set_debug_settings_string();
+  parent->set_debug_add_settings(this->debug_add_settings_);
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
     std::string settings_string;
     if (debug_add_settings_)

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -12,7 +12,7 @@ namespace uart {
 static const char *const TAG = "uart_debug";
 
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
-  this->settings_string_ = parent->get_settings_string();
+  this->settings_string_ = parent->get_debug_settings_string();
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (this->debug_add_settings_)
       settings_string = this->settings_string_;

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -29,7 +29,7 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
 }
 
 void UARTDebugger::loop() {
-  if (this->parent_->debugger_needs_reload())
+  if (this->debug_add_settings_ && this->parent_->debugger_needs_reload())
     this->reload();
   this->trigger_after_timeout_();
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -43,6 +43,7 @@ UARTDebugger::UARTDebugger(UARTComponent *parent) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
+    this->trigger_after_direction_change_(direction);
     this->store_byte_(direction, byte);
     this->trigger_after_delimiter_(byte);
     this->trigger_after_bytes_();

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,6 +14,7 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->set_debug_settings_string();
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, bool debug_add_settings) {
+    std::string settings_string;
     if (debug_add_settings_)
       settings_string = this->settings_string_;
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -76,7 +76,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 std::string UARTDebugger::get_debug_prefix(std::string debug_prefix, bool debug_add_settings) {
    if (!debug_add_settings)
      return debug_prefix;
-   std::string res = "|" + this->baud_rate_;
+   std::string res = "|" + this->parent_->get_baud_rate();
    res += ":" + this->parent_->get_data_bits();
    res += ":" + this->parent_->get_stop_bits();
    switch (this->parent_->get_parity()) {

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -93,7 +93,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
+  trigger(this->last_direction_, this->bytes_, this->final_debug_prefix_);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -18,10 +18,10 @@ UARTDebugger::UARTDebugger(UARTComponent *parent, bool debug_add_settings) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
-    this->trigger_after_direction_change_(direction, debug_add_settings);
+    this->trigger_after_direction_change_(direction, true);
     this->store_byte_(direction, byte);
-    this->trigger_after_delimiter_(byte, debug_add_settings);
-    this->trigger_after_bytes_(debug_add_settings);
+    this->trigger_after_delimiter_(byte, true);
+    this->trigger_after_bytes_(true);
   });
 }
 

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -18,10 +18,10 @@ UARTDebugger::UARTDebugger(UARTComponent *parent, bool debug_add_settings) {
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }
-    this->trigger_after_direction_change_(direction);
+    this->trigger_after_direction_change_(direction, debug_add_settings);
     this->store_byte_(direction, byte);
-    this->trigger_after_delimiter_(byte);
-    this->trigger_after_bytes_();
+    this->trigger_after_delimiter_(byte, debug_add_settings);
+    this->trigger_after_bytes_(debug_add_settings);
   });
 }
 
@@ -33,10 +33,10 @@ bool UARTDebugger::is_my_direction_(UARTDirection direction) {
 
 bool UARTDebugger::is_recursive_() { return this->is_triggering_; }
 
-void UARTDebugger::trigger_after_direction_change_(UARTDirection direction, std::string settings_string) {
+void UARTDebugger::trigger_after_direction_change_(UARTDirection direction, bool debug_add_settings) {
   if (this->has_buffered_bytes_() && this->for_direction_ == UART_DIRECTION_BOTH &&
       this->last_direction_ != direction) {
-    this->fire_trigger_();
+    this->fire_trigger_(debug_add_settings);
   }
 }
 
@@ -46,7 +46,7 @@ void UARTDebugger::store_byte_(UARTDirection direction, uint8_t byte) {
   this->last_time_ = millis();
 }
 
-void UARTDebugger::trigger_after_delimiter_(uint8_t byte, std::string settings_string) {
+void UARTDebugger::trigger_after_delimiter_(uint8_t byte, bool debug_add_settings) {
   if (this->after_delimiter_.empty() || !this->has_buffered_bytes_()) {
     return;
   }
@@ -56,28 +56,28 @@ void UARTDebugger::trigger_after_delimiter_(uint8_t byte, std::string settings_s
   }
   this->after_delimiter_pos_++;
   if (this->after_delimiter_pos_ == this->after_delimiter_.size()) {
-    this->fire_trigger_();
+    this->fire_trigger_(debug_add_settings);
     this->after_delimiter_pos_ = 0;
   }
 }
 
-void UARTDebugger::trigger_after_bytes_(std::string settings_string) {
+void UARTDebugger::trigger_after_bytes_(bool debug_add_settings) {
   if (this->has_buffered_bytes_() && this->after_bytes_ > 0 && this->bytes_.size() >= this->after_bytes_) {
-    this->fire_trigger_();
+    this->fire_trigger_(debug_add_settings);
   }
 }
 
-void UARTDebugger::trigger_after_timeout_(std::string settings_string) {
+void UARTDebugger::trigger_after_timeout_(bool debug_add_settings) {
   if (this->has_buffered_bytes_() && this->after_timeout_ > 0 && millis() - this->last_time_ >= this->after_timeout_) {
-    this->fire_trigger_();
+    this->fire_trigger_(debug_add_settings);
   }
 }
 
 bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
-void UARTDebugger::fire_trigger_() {
+void UARTDebugger::fire_trigger_(bool debug_add_settings) {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, this->debug_add_settings_);
+  trigger(this->last_direction_, this->bytes_, this->debug_prefix_, debug_add_settings);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -75,7 +75,7 @@ bool UARTDebugger::has_buffered_bytes_() { return !this->bytes_.empty(); }
 
 void UARTDebugger::fire_trigger_() {
   this->is_triggering_ = true;
-  trigger(this->last_direction_, this->bytes_, this->debug_settings_string_);
+  trigger(this->last_direction_, this->bytes_, this->debug_prefix_);
   this->bytes_.clear();
   this->is_triggering_ = false;
 }

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -14,7 +14,7 @@ static const char *const TAG = "uart_debug";
 UARTDebugger::UARTDebugger(UARTComponent *parent) {
   parent->add_debug_callback([this](UARTDirection direction, uint8_t byte, std::string debug_prefix, std::string settings_string) {
     if (this->debug_add_settings_)
-      settings_string = this->parent_->get_debug_settings_string();
+      settings_string = parent_->get_debug_settings_string();
     if (!this->is_my_direction_(direction) || this->is_recursive_()) {
       return;
     }

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -11,6 +11,12 @@
 namespace esphome {
 namespace uart {
 
+enum UARTParityOptions {
+  UART_CONFIG_PARITY_NONE,
+  UART_CONFIG_PARITY_EVEN,
+  UART_CONFIG_PARITY_ODD,
+};
+
 enum UARTDirection {
   UART_DIRECTION_RX,
   UART_DIRECTION_TX,

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -82,18 +82,18 @@ class UARTDebug {
  public:
   /// Log the bytes as hex values, separated by the provided separator
   /// character.
-  static void log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix);
+  static void log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix = "");
 
   /// Log the bytes as string values, escaping unprintable characters.
-  static void log_string(UARTDirection direction, std::vector<uint8_t> bytes, std::string debug_prefix);
+  static void log_string(UARTDirection direction, std::vector<uint8_t> bytes, std::string debug_prefix = "");
 
   /// Log the bytes as integer values, separated by the provided separator
   /// character.
-  static void log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix);
+  static void log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix = "");
 
   /// Log the bytes as '<binary> (<hex>)' values, separated by the provided
   /// separator.
-  static void log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix);
+  static void log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix = "");
 };
 
 }  // namespace uart

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -61,7 +61,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   bool is_triggering_{false};
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
-  std::string settings_string_{""};
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -93,7 +93,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   size_t after_delimiter_pos_{};
   bool is_triggering_{false};
   std::string debug_prefix_{""};
-  std::final_debug_prefix_{""};
+  std::string final_debug_prefix_{""};
   bool debug_add_settings_{false};
   uint32_t baud_rate_;
   uint8_t stop_bits_;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -43,8 +43,14 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   void add_delimiter_byte(uint8_t byte) { this->after_delimiter_.push_back(byte); }
 
   // debug settings setters
-  void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
-  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
+  void set_debug_prefix(std::string debug_prefix) { 
+    this->debug_prefix_ = debug_prefix;
+    this->parent_->set_debug_prefix(debug_prefix)
+  }
+  void set_debug_add_settings(bool debug_add_settings) { 
+    this->debug_add_settings_ = debug_add_settings;
+    this->parent_->set_debug_add_settings(debug_add_settings);
+  }
   
  protected:
   UARTDirection for_direction_;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -42,6 +42,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   /// logging will be triggered.
   void add_delimiter_byte(uint8_t byte) { this->after_delimiter_.push_back(byte); }
 
+  void reload();
   
   static std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
     if (!debug_add_settings)

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -42,6 +42,30 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   /// logging will be triggered.
   void add_delimiter_byte(uint8_t byte) { this->after_delimiter_.push_back(byte); }
 
+  
+  static std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
+    if (!debug_add_settings)
+       return debug_prefix;
+     std::string res = "|" + baud_rate;
+     res += ":" + data_bits;
+     res += ":" + stop_bits;
+     switch (parity) {
+       case UART_CONFIG_PARITY_NONE:
+         res += "NONE";
+         break;
+       case UART_CONFIG_PARITY_EVEN:
+         res += "EVEN";
+         break;
+       case UART_CONFIG_PARITY_ODD:
+         res += "ODD";
+         break;
+     default:
+       res += "UNKNOWN";
+       break;
+     }
+     return res + "|" + debug_prefix;
+  }
+
   // debug settings setters
   void set_debug_prefix(std::string debug_prefix) { 
     this->debug_prefix_ = debug_prefix;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -46,21 +46,21 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   static std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
     if (!debug_add_settings)
        return debug_prefix;
-     std::string res = "|" + baud_rate;
-     res += ":" + data_bits;
-     res += ":" + stop_bits;
+     std::string res = "|" + std::to_string(baud_rate);
+     res += ":" + std::to_string(data_bits);
+     res += ":" + std::to_string(stop_bits);
      switch (parity) {
        case UART_CONFIG_PARITY_NONE:
-         res += "NONE";
+         res += ":NONE";
          break;
        case UART_CONFIG_PARITY_EVEN:
-         res += "EVEN";
+         res += ":EVEN";
          break;
        case UART_CONFIG_PARITY_ODD:
-         res += "ODD";
+         res += ":ODD";
          break;
      default:
-       res += "UNKNOWN";
+       res += ":UNKNOWN";
        break;
      }
      return res + "|" + debug_prefix;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -18,7 +18,7 @@ namespace uart {
 /// 'appropriate time' means exactly, is determined by a number of
 /// configurable constraints. E.g. when a given number of bytes is gathered
 /// and/or when no more data has been seen for a given time interval.
-class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string> {
+class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>> {
  public:
   explicit UARTDebugger(UARTComponent *parent);
   void loop() override;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -18,7 +18,7 @@ namespace uart {
 /// 'appropriate time' means exactly, is determined by a number of
 /// configurable constraints. E.g. when a given number of bytes is gathered
 /// and/or when no more data has been seen for a given time interval.
-class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string> {
+class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string = ""> {
  public:
   explicit UARTDebugger(UARTComponent *parent);
   void loop() override;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -45,6 +45,10 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   // add user defined prefix
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
 
+  // get&set bool if settings shall be logged
+  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
+  bool get_debug_add_settings() const { return this->debug_add_settings_; }
+
  protected:
   UARTDirection for_direction_;
   UARTDirection last_direction_{};

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -71,7 +71,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   void trigger_after_bytes_(std::string settings_string = "");
   void trigger_after_timeout_(std::string settings_string = "");
   bool has_buffered_bytes_();
-  void fire_trigger_(std::string settings_string = "");
+  void fire_trigger_();
 };
 
 /// This UARTDevice is used by the serial debugger to read data from a

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -62,10 +62,10 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();
   void store_byte_(UARTDirection direction, uint8_t byte);
-  void trigger_after_direction_change_(UARTDirection direction, std::string settings_string = "");
-  void trigger_after_delimiter_(uint8_t byte, std::string settings_string = "");
-  void trigger_after_bytes_(std::string settings_string = "");
-  void trigger_after_timeout_(std::string settings_string = "");
+  void trigger_after_direction_change_(UARTDirection direction, bool debug_add_settings = false);
+  void trigger_after_delimiter_(uint8_t byte, bool debug_add_settings = false);
+  void trigger_after_bytes_(bool debug_add_settings = false);
+  void trigger_after_timeout_(bool debug_add_settings = false);
   bool has_buffered_bytes_();
   void fire_trigger_();
 };

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -45,12 +45,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   // add user defined prefix
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
 
-  // get&set bool if settings shall be logged
-  void set_debug_add_settings(bool debug_add_settings) { 
-    this->debug_add_settings_ = debug_add_settings;
-  }
-  bool get_debug_add_settings() const { return this->debug_add_settings_; }
-
  protected:
   UARTDirection for_direction_;
   UARTDirection last_direction_{};

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -60,6 +60,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   size_t after_delimiter_pos_{};
   bool is_triggering_{false};
   std::string debug_prefix_{""};
+  std::string debug_settings_string_{""};
   bool debug_add_settings_{false};
 
   bool is_my_direction_(UARTDirection direction);

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -42,49 +42,9 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   /// logging will be triggered.
   void add_delimiter_byte(uint8_t byte) { this->after_delimiter_.push_back(byte); }
 
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-  void reload();
-  
-  static std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate,
-                                      uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
-    if (!debug_add_settings)
-       return debug_prefix;
-     std::string res = "|" + std::to_string(baud_rate);
-     res += ":" + std::to_string(data_bits);
-     res += ":" + std::to_string(stop_bits);
-     switch (parity) {
-       case UART_CONFIG_PARITY_NONE:
-         res += ":NONE";
-         break;
-       case UART_CONFIG_PARITY_EVEN:
-         res += ":EVEN";
-         break;
-       case UART_CONFIG_PARITY_ODD:
-         res += ":ODD";
-         break;
-     default:
-       res += ":UNKNOWN";
-       break;
-     }
-     return res + "|" + debug_prefix;
-  }
-#endif
-
-  // debug setting setters
+  // debug prefix setter
   void set_debug_prefix(std::string debug_prefix) { 
     this->debug_prefix_ = debug_prefix;
-  }
-  void set_debug_add_settings(bool debug_add_settings) {
-    this->debug_add_settings_ = debug_add_settings;
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-    if (debug_add_settings)
-      this->final_debug_prefix_= get_debug_prefix(this->debug_prefix_,
-                                                  this->debug_add_settings_,
-                                                  this->baud_rate_,
-                                                  this->data_bits_,
-                                                  this->stop_bits_,
-                                                  this->parity_);
-#endif
   }
   
  protected:
@@ -98,15 +58,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   size_t after_delimiter_pos_{};
   bool is_triggering_{false};
   std::string debug_prefix_{""};
-  bool debug_add_settings_{false};
-#ifdef UART_DEBUGGER_ADD_SETTINGS
-  std::string final_debug_prefix_{""};
-  uint32_t baud_rate_;
-  uint8_t stop_bits_;
-  uint8_t data_bits_;
-  UARTParityOptions parity_;
-  UARTComponent* parent_;
-#endif
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -18,7 +18,7 @@ namespace uart {
 /// 'appropriate time' means exactly, is determined by a number of
 /// configurable constraints. E.g. when a given number of bytes is gathered
 /// and/or when no more data has been seen for a given time interval.
-class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string = ""> {
+class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string> {
  public:
   explicit UARTDebugger(UARTComponent *parent);
   void loop() override;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -11,6 +11,12 @@
 namespace esphome {
 namespace uart {
 
+enum UARTDirection {
+  UART_DIRECTION_RX,
+  UART_DIRECTION_TX,
+  UART_DIRECTION_BOTH,
+};
+
 /// The UARTDebugger class adds debugging support to a UART bus.
 ///
 /// It accumulates bytes that travel over the UART bus and triggers one or

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -62,12 +62,12 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();
   void store_byte_(UARTDirection direction, uint8_t byte);
-  void trigger_after_direction_change_(UARTDirection direction, bool debug_add_settings = false);
-  void trigger_after_delimiter_(uint8_t byte, bool debug_add_settings = false);
-  void trigger_after_bytes_(bool debug_add_settings = false);
-  void trigger_after_timeout_(bool debug_add_settings = false);
+  void trigger_after_direction_change_(UARTDirection direction);
+  void trigger_after_delimiter_(uint8_t byte);
+  void trigger_after_bytes_();
+  void trigger_after_timeout_();
   bool has_buffered_bytes_();
-  void fire_trigger_(bool debug_add_settings = false);
+  void fire_trigger_();
 };
 
 /// This UARTDevice is used by the serial debugger to read data from a
@@ -88,22 +88,18 @@ class UARTDebug {
  public:
   /// Log the bytes as hex values, separated by the provided separator
   /// character.
-  static void log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator,
-                      std::string debug_prefix = "", std::string debug_settings_string = "");
+  static void log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator);
 
   /// Log the bytes as string values, escaping unprintable characters.
-  static void log_string(UARTDirection direction, std::vector<uint8_t> bytes,
-                         std::string debug_prefix = "", std::string debug_settings_string = "");
+  static void log_string(UARTDirection direction, std::vector<uint8_t> bytes);
 
   /// Log the bytes as integer values, separated by the provided separator
   /// character.
-  static void log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator,
-                      std::string debug_prefix = "", std::string debug_settings_string = "");
+  static void log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator);
 
   /// Log the bytes as '<binary> (<hex>)' values, separated by the provided
   /// separator.
-  static void log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator,
-                         std::string debug_prefix = "", std::string debug_settings_string = "");
+  static void log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator);
 };
 
 }  // namespace uart

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -45,6 +45,9 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   // add user defined prefix
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
 
+  // set bool if uart channel settings shall be added
+  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
+
  protected:
   UARTDirection for_direction_;
   UARTDirection last_direction_{};

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -41,6 +41,10 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   /// When the constructed byte sequence is found in the data stream,
   /// logging will be triggered.
   void add_delimiter_byte(uint8_t byte) { this->after_delimiter_.push_back(byte); }
+
+  // debug settings setters
+  void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
+  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
   
  protected:
   UARTDirection for_direction_;
@@ -53,6 +57,8 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   size_t after_delimiter_pos_{};
   bool is_triggering_{false};
   std::string debug_prefix_{""};
+  bool debug_add_settings_{false};
+  UARTComponent* parent_;
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -61,6 +61,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   bool is_triggering_{false};
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
+  std::string settings_string_{""};
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -48,7 +48,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   }
   void set_debug_add_settings(bool debug_add_settings) { 
     this->debug_add_settings_ = debug_add_settings;
-    this->debug_prefix_= this->parent_->get_debug_prefix(this->debug_prefix_, debug_add_settings);
   }
 
   std::string get_debug_prefix();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -11,18 +11,6 @@
 namespace esphome {
 namespace uart {
 
-enum UARTParityOptions {
-  UART_CONFIG_PARITY_NONE,
-  UART_CONFIG_PARITY_EVEN,
-  UART_CONFIG_PARITY_ODD,
-};
-
-enum UARTDirection {
-  UART_DIRECTION_RX,
-  UART_DIRECTION_TX,
-  UART_DIRECTION_BOTH,
-};
-
 /// The UARTDebugger class adds debugging support to a UART bus.
 ///
 /// It accumulates bytes that travel over the UART bus and triggers one or

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -45,7 +45,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   // debug settings setters
   void set_debug_prefix(std::string debug_prefix) { 
     this->debug_prefix_ = debug_prefix;
-    this->parent_->set_debug_prefix(debug_prefix)
+    this->parent_->set_debug_prefix(debug_prefix);
   }
   void set_debug_add_settings(bool debug_add_settings) { 
     this->debug_add_settings_ = debug_add_settings;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -91,18 +91,18 @@ class UARTDebug {
  public:
   /// Log the bytes as hex values, separated by the provided separator
   /// character.
-  static void log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator);
+  static void log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix);
 
   /// Log the bytes as string values, escaping unprintable characters.
-  static void log_string(UARTDirection direction, std::vector<uint8_t> bytes);
+  static void log_string(UARTDirection direction, std::vector<uint8_t> bytes, std::string debug_prefix);
 
   /// Log the bytes as integer values, separated by the provided separator
   /// character.
-  static void log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator);
+  static void log_int(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix);
 
   /// Log the bytes as '<binary> (<hex>)' values, separated by the provided
   /// separator.
-  static void log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator);
+  static void log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator, std::string debug_prefix);
 };
 
 }  // namespace uart

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -65,7 +65,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
   std::string debug_settings_string_{""};
-  UARTComponent* parent_;
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -42,12 +42,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   /// logging will be triggered.
   void add_delimiter_byte(uint8_t byte) { this->after_delimiter_.push_back(byte); }
   
-  // add user defined prefix
-  void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
-
-  // set bool if uart channel settings shall be added
-  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
-
  protected:
   UARTDirection for_direction_;
   UARTDirection last_direction_{};
@@ -58,9 +52,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   std::vector<uint8_t> after_delimiter_{};
   size_t after_delimiter_pos_{};
   bool is_triggering_{false};
-  std::string debug_prefix_{""};
-  std::string debug_settings_string_{""};
-  bool debug_add_settings_{false};
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -44,8 +44,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   
   // add user defined prefix
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
-  // shall uart channel settings be added to string ?
-  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
 
  protected:
   UARTDirection for_direction_;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -18,7 +18,7 @@ namespace uart {
 /// 'appropriate time' means exactly, is determined by a number of
 /// configurable constraints. E.g. when a given number of bytes is gathered
 /// and/or when no more data has been seen for a given time interval.
-class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string, std::string> {
+class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string, bool> {
  public:
   explicit UARTDebugger(UARTComponent *parent);
   void loop() override;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -48,6 +48,9 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   }
   void set_debug_add_settings(bool debug_add_settings) { 
     this->debug_add_settings_ = debug_add_settings;
+    this->debug_prefix_= get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
+                                          this->data_bits_, this->stop_bits_, this->parity_);
+    this->trigger_after_direction_change_(direction);
   }
   
  protected:

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -63,12 +63,12 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();
   void store_byte_(UARTDirection direction, uint8_t byte);
-  void trigger_after_direction_change_(UARTDirection direction);
-  void trigger_after_delimiter_(uint8_t byte);
-  void trigger_after_bytes_();
-  void trigger_after_timeout_();
+  void trigger_after_direction_change_(UARTDirection direction, std::string settings_string = "");
+  void trigger_after_delimiter_(uint8_t byte, std::string settings_string = "");
+  void trigger_after_bytes_(std::string settings_string = "");
+  void trigger_after_timeout_(std::string settings_string = "");
   bool has_buffered_bytes_();
-  void fire_trigger_();
+  void fire_trigger_(std::string settings_string = "");
 };
 
 /// This UARTDevice is used by the serial debugger to read data from a

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -49,8 +49,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   void set_debug_add_settings(bool debug_add_settings) { 
     this->debug_add_settings_ = debug_add_settings;
   }
-
-  std::string get_debug_prefix();
+  std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings);
   
  protected:
   UARTDirection for_direction_;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -64,6 +64,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   bool is_triggering_{false};
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
+  std::string debug_settings_string_{""};
   UARTComponent* parent_;
 
   bool is_my_direction_(UARTDirection direction);

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -52,6 +52,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   std::vector<uint8_t> after_delimiter_{};
   size_t after_delimiter_pos_{};
   bool is_triggering_{false};
+  std::string debug_prefix_{""};
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -49,7 +49,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   void set_debug_add_settings(bool debug_add_settings) { 
     this->debug_add_settings_ = debug_add_settings;
   }
-  std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings);
   
  protected:
   UARTDirection for_direction_;
@@ -63,7 +62,10 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   bool is_triggering_{false};
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
-  UARTComponent* parent_;
+  uint32_t baud_rate_;
+  uint8_t stop_bits_;
+  uint8_t data_bits_;
+  UARTParityOptions parity_;
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -50,7 +50,6 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
     this->debug_add_settings_ = debug_add_settings;
     this->debug_prefix_= get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
                                           this->data_bits_, this->stop_bits_, this->parity_);
-    this->trigger_after_direction_change_(direction);
   }
   
  protected:

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -18,7 +18,7 @@ namespace uart {
 /// 'appropriate time' means exactly, is determined by a number of
 /// configurable constraints. E.g. when a given number of bytes is gathered
 /// and/or when no more data has been seen for a given time interval.
-class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>> {
+class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string> {
  public:
   explicit UARTDebugger(UARTComponent *parent);
   void loop() override;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -48,6 +48,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   }
   void set_debug_add_settings(bool debug_add_settings) { 
     this->debug_add_settings_ = debug_add_settings;
+    this->debug_prefix_= this->parent_->get_debug_prefix(this->debug_prefix_, debug_add_settings);
   }
 
   std::string get_debug_prefix();
@@ -64,7 +65,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   bool is_triggering_{false};
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
-  std::string debug_settings_string_{""};
+  UARTComponent* parent_;
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -18,9 +18,9 @@ namespace uart {
 /// 'appropriate time' means exactly, is determined by a number of
 /// configurable constraints. E.g. when a given number of bytes is gathered
 /// and/or when no more data has been seen for a given time interval.
-class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string, bool> {
+class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>> {
  public:
-  explicit UARTDebugger(UARTComponent *parent, bool debug_add_settings);
+  explicit UARTDebugger(UARTComponent *parent);
   void loop() override;
 
   /// Set the direction in which to inspect the bytes: incoming, outgoing

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -100,6 +100,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   std::string debug_prefix_{""};
   bool debug_add_settings_{false};
 #ifdef UART_DEBUGGER_ADD_SETTINGS
+  std::string final_debug_prefix_{""};
   uint32_t baud_rate_;
   uint8_t stop_bits_;
   uint8_t data_bits_;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -67,14 +67,19 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
      return res + "|" + debug_prefix;
   }
 
-  // debug settings setters
+  // debug setting setters
   void set_debug_prefix(std::string debug_prefix) { 
     this->debug_prefix_ = debug_prefix;
   }
   void set_debug_add_settings(bool debug_add_settings) { 
     this->debug_add_settings_ = debug_add_settings;
-    this->debug_prefix_= get_debug_prefix(this->debug_prefix_, this->debug_add_settings_, this->baud_rate_,
-                                          this->data_bits_, this->stop_bits_, this->parity_);
+    if (debug_add_settings)
+      this->final_debug_prefix_= get_debug_prefix(this->debug_prefix_,
+                                                  this->debug_add_settings_,
+                                                  this->baud_rate_,
+                                                  this->data_bits_,
+                                                  this->stop_bits_,
+                                                  this->parity_);
   }
   
  protected:
@@ -88,6 +93,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   size_t after_delimiter_pos_{};
   bool is_triggering_{false};
   std::string debug_prefix_{""};
+  std::final_debug_prefix_{""};
   bool debug_add_settings_{false};
   uint32_t baud_rate_;
   uint8_t stop_bits_;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -49,6 +49,8 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   void set_debug_add_settings(bool debug_add_settings) { 
     this->debug_add_settings_ = debug_add_settings;
   }
+
+  std::string get_debug_prefix();
   
  protected:
   UARTDirection for_direction_;

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -45,11 +45,9 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   // debug settings setters
   void set_debug_prefix(std::string debug_prefix) { 
     this->debug_prefix_ = debug_prefix;
-    this->parent_->set_debug_prefix(debug_prefix);
   }
   void set_debug_add_settings(bool debug_add_settings) { 
     this->debug_add_settings_ = debug_add_settings;
-    this->parent_->set_debug_add_settings(debug_add_settings);
   }
   
  protected:

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -67,7 +67,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   void trigger_after_bytes_(bool debug_add_settings = false);
   void trigger_after_timeout_(bool debug_add_settings = false);
   bool has_buffered_bytes_();
-  void fire_trigger_();
+  void fire_trigger_(bool debug_add_settings = false);
 };
 
 /// This UARTDevice is used by the serial debugger to read data from a

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -44,7 +44,8 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
 
   void reload();
   
-  static std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate, uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
+  static std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate,
+                                      uint8_t data_bits, uint8_t stop_bits, uint8_t parity) {
     if (!debug_add_settings)
        return debug_prefix;
      std::string res = "|" + std::to_string(baud_rate);

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -93,6 +93,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   uint8_t stop_bits_;
   uint8_t data_bits_;
   UARTParityOptions parity_;
+  UARTComponent* parent_;
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -42,6 +42,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   /// logging will be triggered.
   void add_delimiter_byte(uint8_t byte) { this->after_delimiter_.push_back(byte); }
 
+#ifdef UART_DEBUGGER_ADD_SETTINGS
   void reload();
   
   static std::string get_debug_prefix(std::string debug_prefix, bool debug_add_settings, uint32_t baud_rate,
@@ -67,13 +68,15 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
      }
      return res + "|" + debug_prefix;
   }
+#endif
 
   // debug setting setters
   void set_debug_prefix(std::string debug_prefix) { 
     this->debug_prefix_ = debug_prefix;
   }
-  void set_debug_add_settings(bool debug_add_settings) { 
+  void set_debug_add_settings(bool debug_add_settings) {
     this->debug_add_settings_ = debug_add_settings;
+#ifdef UART_DEBUGGER_ADD_SETTINGS
     if (debug_add_settings)
       this->final_debug_prefix_= get_debug_prefix(this->debug_prefix_,
                                                   this->debug_add_settings_,
@@ -81,6 +84,7 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
                                                   this->data_bits_,
                                                   this->stop_bits_,
                                                   this->parity_);
+#endif
   }
   
  protected:
@@ -94,13 +98,14 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   size_t after_delimiter_pos_{};
   bool is_triggering_{false};
   std::string debug_prefix_{""};
-  std::string final_debug_prefix_{""};
   bool debug_add_settings_{false};
+#ifdef UART_DEBUGGER_ADD_SETTINGS
   uint32_t baud_rate_;
   uint8_t stop_bits_;
   uint8_t data_bits_;
   UARTParityOptions parity_;
   UARTComponent* parent_;
+#endif
 
   bool is_my_direction_(UARTDirection direction);
   bool is_recursive_();

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -20,7 +20,7 @@ namespace uart {
 /// and/or when no more data has been seen for a given time interval.
 class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector<uint8_t>, std::string, bool> {
  public:
-  explicit UARTDebugger(UARTComponent *parent);
+  explicit UARTDebugger(UARTComponent *parent, bool debug_add_settings);
   void loop() override;
 
   /// Set the direction in which to inspect the bytes: incoming, outgoing
@@ -46,7 +46,9 @@ class UARTDebugger : public Component, public Trigger<UARTDirection, std::vector
   void set_debug_prefix(std::string debug_prefix) { this->debug_prefix_ = debug_prefix; }
 
   // get&set bool if settings shall be logged
-  void set_debug_add_settings(bool debug_add_settings) { this->debug_add_settings_ = debug_add_settings; }
+  void set_debug_add_settings(bool debug_add_settings) { 
+    this->debug_add_settings_ = debug_add_settings;
+  }
   bool get_debug_add_settings() const { return this->debug_add_settings_; }
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Add option "debug_prefix" to add static prefix string, which is prepended before every uart debug log string
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:
uart:
  - id: uart_channel_1
    baud_rate: 115200
    tx_pin: GPIO26
    rx_pin: GPIO27
    debug:
      debug_prefix: "host uart 1: "
```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
