### PR TITLE
Claude/new project setup

### DIFF
--- a/esphome/components/usb_msc_host/__init__.py
+++ b/esphome/components/usb_msc_host/__init__.py
@@ -23,7 +23,8 @@ USBMscHost = usb_msc_host_ns.class_("USBMscHost", cg.Component)
 
 async def register_usb_msc_client(config):
     var = cg.new_Pvariable(config[CONF_ID], config[CONF_VID], config[CONF_PID])
-    await cg.register_parented(var, config)
+    await cg.register_component(var, config)  # Register as Component for loop() calls
+    await cg.register_parented(var, config)   # Register parent relationship for USBMscHost access
     return var
 
 


### PR DESCRIPTION
…() execution

USBMscDevice was only registered via register_parented(), which prevented the ESPHome framework from calling its loop() method. This caused USB events to never be processed, preventing on_connected() from being triggered.

Now registers both as Component (for loop() calls) and as parented (for USBMscHost parent access), matching the pattern used in usb_host component.

This fixes the issue where USB MSC devices were detected but never mounted.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
