### PR TITLE
[usb_msc_host] Fix: Correct string constant declarations to const char*

### DIFF
--- a/esphome/components/usb_msc_host/usb_msc_host.h
+++ b/esphome/components/usb_msc_host/usb_msc_host.h
@@ -29,7 +29,7 @@
 namespace esphome {
 namespace usb_msc_host {
 
-static constexpr char *const MNT_PATH = "/usb";
+static constexpr const char *MNT_PATH = "/usb";
 static constexpr uint16_t BUFFER_SIZE = 4096;
 static constexpr uint8_t MAX_MSC_DEVICES = CONFIG_FATFS_VOLUME_COUNT;
 
@@ -45,7 +45,7 @@ typedef struct {
   msc_host_vfs_handle_t vfs_handle;    /*!< VFS handle assigned to the MSC device */
 } msc_dev_entry_t;
 
-static constexpr char *const TAG = "usb_msc_host";
+static constexpr const char *TAG = "usb_msc_host";
 static constexpr uint8_t SCSI_COMMAND_SET = 0x06;
 static constexpr uint8_t BULK_ONLY_TRANSFER = 0x50;
 


### PR DESCRIPTION
Fixed ISO C++ warning: "forbids converting a string constant to 'char*'"

Changed from:
  static constexpr char *const TAG = "...";
  static constexpr char *const MNT_PATH = "...";

To:
  static constexpr const char *TAG = "...";
  static constexpr const char *MNT_PATH = "...";

String literals in C++ are of type const char[], so pointers to them must be const char*, not char*.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
