### PR TITLE
[usb_msc_host] Fix: Use cg.get_variable() to resolve parent instance

### DIFF
--- a/esphome/components/usb_msc_host/__init__.py
+++ b/esphome/components/usb_msc_host/__init__.py
@@ -15,16 +15,20 @@ CODEOWNERS = ["p1ngb4ck"]
 DEPENDENCIES = ["usb_host", "esp32"]
 AUTO_LOAD = []
 
+CONF_USB_MSC_HOST_ID = "usb_msc_host_id"
+
 require_vfs_dir()
 
 usb_msc_host_ns = cg.esphome_ns.namespace("usb_msc_host")
 USBMscHost = usb_msc_host_ns.class_("USBMscHost", cg.Component)
 
 
-async def register_usb_msc_client(device_config, parent):
+async def register_usb_msc_client(device_config, parent_id):
     var = cg.new_Pvariable(device_config[CONF_ID], device_config[CONF_VID], device_config[CONF_PID])
     await cg.register_component(var, device_config)  # Register as Component for loop() calls
-    cg.add(var.set_parent(parent))  # Manually set parent relationship
+    # Set parent by calling the Parented<USBMscHost>::set_parent() method
+    paren = await cg.get_variable(parent_id)
+    cg.add(var.set_parent(paren))
     return var
 
 
@@ -45,4 +49,4 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     for device in config.get(CONF_DEVICES) or ():
-        await register_usb_msc_client(device, var)
+        await register_usb_msc_client(device, config[CONF_ID])


### PR DESCRIPTION
Fixed error: 'class esphome::usb_host::USBClient' has no member named 'set_parent'

The issue was that we were passing the Python var object directly instead of resolving it through the code generator. The set_parent() method exists in Parented<USBMscHost> but needs proper code generation.

Changes:
- Pass parent_id (config[CONF_ID]) instead of var object
- Use await cg.get_variable(parent_id) to resolve parent at codegen time
- This generates correct C++ code: device->set_parent(parent_instance)

The Parented<T> base class provides set_parent(), this fix ensures it's called correctly during code generation.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
