### PR TITLE
[usb_msc_host] Fix: Declare USBMscDevice class with proper inheritance

### DIFF
--- a/esphome/components/usb_msc_host/__init__.py
+++ b/esphome/components/usb_msc_host/__init__.py
@@ -7,7 +7,8 @@ from esphome.components.esp32 import (
     only_on_variant,
     require_vfs_dir,
 )
-from esphome.components.usb_host import CONF_PID, CONF_VID, usb_device_schema
+from esphome.components import usb_host
+from esphome.components.usb_host import CONF_PID, CONF_VID, USBClient, usb_device_schema
 import esphome.config_validation as cv
 from esphome.const import CONF_DEVICES, CONF_ID
 
@@ -21,6 +22,7 @@ require_vfs_dir()
 
 usb_msc_host_ns = cg.esphome_ns.namespace("usb_msc_host")
 USBMscHost = usb_msc_host_ns.class_("USBMscHost", cg.Component)
+USBMscDevice = usb_msc_host_ns.class_("USBMscDevice", USBClient, cg.Parented.template(USBMscHost))
 
 
 async def register_usb_msc_client(device_config, parent_id):
@@ -36,7 +38,7 @@ CONFIG_SCHEMA = cv.All(
     cv.COMPONENT_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(USBMscHost),
-            cv.Optional(CONF_DEVICES): cv.ensure_list(usb_device_schema()),
+            cv.Optional(CONF_DEVICES): cv.ensure_list(usb_device_schema(USBMscDevice)),
         }
     ),
     cv.only_with_esp_idf,


### PR DESCRIPTION
Fixed error: 'class esphome::usb_host::USBClient' has no member named 'set_parent'

Root cause: usb_device_schema() defaults to declaring IDs as USBClient*, but USBClient doesn't have set_parent() - only USBMscDevice has it through Parented<USBMscHost> inheritance.

Changes:
- Import USBClient from usb_host component
- Declare USBMscDevice class with proper base classes:
  - USBClient (for USB functionality)
  - Parented<USBMscHost> (provides set_parent() method)
- Pass USBMscDevice to usb_device_schema() so IDs are declared correctly

This ensures generated C++ code uses USBMscDevice* which has set_parent(), not USBClient* which doesn't.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
