### PR TITLE
[usb_uart] Fix: Import USBClient instead of re-declaring it

### DIFF
--- a/esphome/components/usb_uart/__init__.py
+++ b/esphome/components/usb_uart/__init__.py
@@ -6,7 +6,7 @@ from esphome.components.uart import (
     CONF_STOP_BITS,
     UARTComponent,
 )
-from esphome.components.usb_host import register_usb_client, usb_device_schema, usb_host_ns
+from esphome.components.usb_host import register_usb_client, usb_device_schema, USBClient
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BAUD_RATE,
@@ -23,7 +23,6 @@ AUTO_LOAD = ["uart", "usb_host", "bytebuffer"]
 CODEOWNERS = ["@clydebarrow"]
 
 usb_uart_ns = cg.esphome_ns.namespace("usb_uart")
-USBClient = usb_host_ns.class_("USBClient")
 USBUartComponent = usb_uart_ns.class_("USBUartComponent", USBClient)
 USBUartChannel = usb_uart_ns.class_("USBUartChannel", UARTComponent)
 


### PR DESCRIPTION
Previous commit attempted to fix the inheritance but incorrectly re-declared USBClient without base classes, causing: "Component ID was not declared to inherit from Component"

Fix: Import USBClient directly from usb_host module, which already has the complete declaration with all base classes:
  USBClient(Component, Parented<USBHost>)

This ensures USBUartComponent inherits the full type information.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
