### PR TITLE
[usb_uart] Fix USBUartComponent Python declaration to inherit from US…

### DIFF
--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -193,6 +193,10 @@ class USBUartComponent : public usb_host::USBClient {
 
   void add_channel(USBUartChannel *channel) { this->channels_.push_back(channel); }
 
+  // Make on_connected public so derived classes can override it properly
+  // This fixes the virtual dispatch chain from protected (USBClient) to public overrides
+  void on_connected() override {}
+
   virtual void start_input(USBUartChannel *channel);
   virtual void start_output(USBUartChannel *channel);
 


### PR DESCRIPTION
…BClient

Root cause: The virtual dispatch chain from USBClient (protected on_connected) to derived classes (public on_connected overrides) was broken because USBUartComponent did not redeclare on_connected().

When USBClient::loop() calls this->on_connected(), the virtual dispatch needs a continuous chain:
- USBClient::on_connected() (protected virtual)
- USBUartComponent::on_connected() (public override) <- WAS MISSING
- USBUartTypeCH934X::on_connected() (public override)

Without the middle declaration, C++ might not properly dispatch the virtual call from protected (USBClient) to public (CH934X), especially when the call originates from within the base class.

Fix: Add public on_connected() override declaration in USBUartComponent to establish the proper virtual dispatch chain. The empty implementation serves as a bridge - all derived classes (CdcAcm, CH934X, etc.) override it anyway.

This ensures proper virtual dispatch regardless of access modifier transitions.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
