### PR TITLE
[usb_uart] Move on_connected() to protected for consistent access hie…

### DIFF
--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -193,10 +193,6 @@ class USBUartComponent : public usb_host::USBClient {
 
   void add_channel(USBUartChannel *channel) { this->channels_.push_back(channel); }
 
-  // Make on_connected public so derived classes can override it properly
-  // This fixes the virtual dispatch chain from protected (USBClient) to public overrides
-  void on_connected() override {}
-
   virtual void start_input(USBUartChannel *channel);
   virtual void start_output(USBUartChannel *channel);
 
@@ -206,6 +202,10 @@ class USBUartComponent : public usb_host::USBClient {
   EventPool<UsbDataChunk, USB_DATA_QUEUE_SIZE> chunk_pool_;
 
  protected:
+  // Re-declare on_connected as protected to maintain virtual dispatch chain
+  // Called from USBClient::loop() (protected context), overridden by derived classes
+  void on_connected() override {}
+
   std::vector<USBUartChannel *> channels_{};
 };
 
@@ -261,18 +261,18 @@ class USBUartTypeCH934X : public USBUartComponent {
     ESP_LOGI("usb_uart", "=== CH934X CONSTRUCTOR CALLED! VID=%04X PID=%04X ===", vid, pid);
   }
 
-  // Overridden methods from USBUartComponent
-  void on_connected() override;
-  void on_disconnected() override;
-  void start_input(USBUartChannel *channel) override;
-  void start_output(USBUartChannel *channel) override;
-  bool parse_descriptors(usb_device_handle_t dev_hdl);
-  void enable_channels();
-
   // ESPHome component loop - handles RX queue processing and TX multiplexing
   void loop() override;
 
+  void start_input(USBUartChannel *channel) override;
+  void start_output(USBUartChannel *channel) override;
+
  protected:
+  // Virtual method overrides - keep protected like in USBUartTypeCdcAcm for consistency
+  void on_connected() override;
+  void on_disconnected() override;
+  bool parse_descriptors(usb_device_handle_t dev_hdl);
+  void enable_channels();
   // Device-level configuration
   void configure_device_();
   void configure_channels_after_detection_();  // Called via defer after chip detection


### PR DESCRIPTION
…rarchy

Changed on_connected() from public to protected in:
- USBUartComponent (line 207)
- USBUartTypeCH934X (line 272)

This ensures consistent access modifiers throughout the inheritance chain:
- USBClient::on_connected() - protected (base)
- USBUartComponent::on_connected() - protected (intermediate)
- USBUartTypeCdcAcm::on_connected() - protected (derived)
- USBUartTypeCH934X::on_connected() - protected (derived)

Access analysis shows no external calls to on_connected() - only internal call via this->on_connected() in USBClient::loop(), so this change is safe.

Consistent protected access modifiers ensure proper virtual dispatch across the entire inheritance hierarchy without access modifier mismatches.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
