### PR TITLE
[webdav_server] Add detailed error logging for handler registration

### DIFF
--- a/esphome/components/webdav_server/webdav_server.cpp
+++ b/esphome/components/webdav_server/webdav_server.cpp
@@ -93,14 +93,65 @@ bool WebDAVServer::start_server() {
       .user_ctx = this,
   };
 
-  httpd_register_uri_handler(this->server_, &get_handler);
-  httpd_register_uri_handler(this->server_, &put_handler);
-  httpd_register_uri_handler(this->server_, &delete_handler);
-  httpd_register_uri_handler(this->server_, &propfind_handler);
-  httpd_register_uri_handler(this->server_, &mkcol_handler);
-  httpd_register_uri_handler(this->server_, &move_handler);
-  httpd_register_uri_handler(this->server_, &copy_handler);
+  esp_err_t err;
 
+  err = httpd_register_uri_handler(this->server_, &get_handler);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register GET handler: %s", esp_err_to_name(err));
+    httpd_stop(this->server_);
+    return false;
+  }
+  ESP_LOGD(TAG, "Registered GET handler");
+
+  err = httpd_register_uri_handler(this->server_, &put_handler);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register PUT handler: %s", esp_err_to_name(err));
+    httpd_stop(this->server_);
+    return false;
+  }
+  ESP_LOGD(TAG, "Registered PUT handler");
+
+  err = httpd_register_uri_handler(this->server_, &delete_handler);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register DELETE handler: %s", esp_err_to_name(err));
+    httpd_stop(this->server_);
+    return false;
+  }
+  ESP_LOGD(TAG, "Registered DELETE handler");
+
+  err = httpd_register_uri_handler(this->server_, &propfind_handler);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register PROPFIND handler: %s", esp_err_to_name(err));
+    httpd_stop(this->server_);
+    return false;
+  }
+  ESP_LOGD(TAG, "Registered PROPFIND handler");
+
+  err = httpd_register_uri_handler(this->server_, &mkcol_handler);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register MKCOL handler: %s", esp_err_to_name(err));
+    httpd_stop(this->server_);
+    return false;
+  }
+  ESP_LOGD(TAG, "Registered MKCOL handler");
+
+  err = httpd_register_uri_handler(this->server_, &move_handler);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register MOVE handler: %s", esp_err_to_name(err));
+    httpd_stop(this->server_);
+    return false;
+  }
+  ESP_LOGD(TAG, "Registered MOVE handler");
+
+  err = httpd_register_uri_handler(this->server_, &copy_handler);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register COPY handler: %s", esp_err_to_name(err));
+    httpd_stop(this->server_);
+    return false;
+  }
+  ESP_LOGD(TAG, "Registered COPY handler");
+
+  ESP_LOGI(TAG, "All handlers registered successfully");
   return true;
 }
 


### PR DESCRIPTION
Added comprehensive error checking and logging for each HTTP handler registration to identify which specific handler fails during server startup.

Changes:
- Check return value of each httpd_register_uri_handler() call
- Log error with esp_err_to_name() if registration fails
- Stop server and return false on first failure
- Add debug logs for each successful handler registration
- Add final success log when all handlers registered

This will help diagnose why webdav_server fails to start.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
