### PR TITLE
[webdav_server] Fix root_path handling for filesystem root "/"

### DIFF
--- a/esphome/components/webdav_server/webdav_server.cpp
+++ b/esphome/components/webdav_server/webdav_server.cpp
@@ -201,8 +201,8 @@ std::string WebDAVServer::uri_to_filepath(const std::string &uri) {
   // Handle empty path (root access)
   if (relative_path.empty()) {
     std::string root = this->root_path_;
-    // Remove trailing slash for root
-    if (!root.empty() && root.back() == '/') {
+    // Remove trailing slash for root, UNLESS root is exactly "/"
+    if (!root.empty() && root.back() == '/' && root.length() > 1) {
       root = root.substr(0, root.length() - 1);
     }
     ESP_LOGD(TAG, "Root access: %s", root.c_str());


### PR DESCRIPTION
Fixed issue where root_path="/" was converted to empty string "", causing "Path not found" errors when accessing the filesystem root.

Changed uri_to_filepath() to only remove trailing slash if the path length is > 1. This preserves "/" as the root path while still removing trailing slashes from paths like "/usb0/".

This allows WebDAV to access all mount points at the filesystem root (e.g., /usb0, /usb1, /sd) for multi-storage support.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
