### PR TITLE
[webdav_server] Fix COPY/MOVE operations to handle full URLs in Desti…

### DIFF
--- a/esphome/components/webdav_server/webdav_server.cpp
+++ b/esphome/components/webdav_server/webdav_server.cpp
@@ -265,6 +265,24 @@ std::string WebDAVServer::url_decode(const std::string &src) {
   return result;
 }
 
+std::string WebDAVServer::extract_path_from_url(const std::string &url) {
+  // Check if it's a full URL (starts with http:// or https://)
+  if (url.find("http://") == 0 || url.find("https://") == 0) {
+    // Find the third slash (after protocol://host:port/)
+    size_t first_slash = url.find("//");
+    if (first_slash != std::string::npos) {
+      size_t path_start = url.find('/', first_slash + 2);
+      if (path_start != std::string::npos) {
+        std::string path = url.substr(path_start);
+        ESP_LOGD(TAG, "Extracted path from URL: %s -> %s", url.c_str(), path.c_str());
+        return path;
+      }
+    }
+  }
+  // Not a URL or parsing failed - return as-is
+  return url;
+}
+
 std::string WebDAVServer::generate_prop_xml(const std::string &href, bool is_directory, time_t modified,
                                             size_t size) {
   char time_buf[50];
@@ -620,6 +638,7 @@ esp_err_t WebDAVServer::handle_move(httpd_req_t *req) {
   auto *server = static_cast<WebDAVServer *>(req->user_ctx);
 
   std::string filepath = server->uri_to_filepath(req->uri);
+  ESP_LOGD(TAG, "MOVE request for: %s", filepath.c_str());
 
   char dest_buf[512];
   if (httpd_req_get_hdr_value_str(req, "Destination", dest_buf, sizeof(dest_buf)) != ESP_OK) {
@@ -627,11 +646,17 @@ esp_err_t WebDAVServer::handle_move(httpd_req_t *req) {
     return ESP_OK;
   }
 
-  std::string dest_filepath = server->uri_to_filepath(dest_buf);
+  // Extract path from full URL if needed
+  std::string dest_path = server->extract_path_from_url(dest_buf);
+  std::string dest_filepath = server->uri_to_filepath(dest_path);
+
+  ESP_LOGD(TAG, "MOVE destination: %s", dest_filepath.c_str());
 
   if (rename(filepath.c_str(), dest_filepath.c_str()) == 0) {
+    httpd_resp_set_status(req, "201 Created");
     httpd_resp_send(req, "Resource moved", -1);
   } else {
+    ESP_LOGE(TAG, "Failed to move %s to %s (errno: %d)", filepath.c_str(), dest_filepath.c_str(), errno);
     httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Cannot move resource");
   }
 
@@ -642,6 +667,7 @@ esp_err_t WebDAVServer::handle_copy(httpd_req_t *req) {
   auto *server = static_cast<WebDAVServer *>(req->user_ctx);
 
   std::string filepath = server->uri_to_filepath(req->uri);
+  ESP_LOGD(TAG, "COPY request for: %s", filepath.c_str());
 
   char dest_buf[512];
   if (httpd_req_get_hdr_value_str(req, "Destination", dest_buf, sizeof(dest_buf)) != ESP_OK) {
@@ -649,7 +675,11 @@ esp_err_t WebDAVServer::handle_copy(httpd_req_t *req) {
     return ESP_OK;
   }
 
-  std::string dest_filepath = server->uri_to_filepath(dest_buf);
+  // Extract path from full URL if needed
+  std::string dest_path = server->extract_path_from_url(dest_buf);
+  std::string dest_filepath = server->uri_to_filepath(dest_path);
+
+  ESP_LOGD(TAG, "COPY destination: %s", dest_filepath.c_str());
 
   // Simple file copy
   std::ifstream src(filepath, std::ios::binary);
@@ -659,8 +689,10 @@ esp_err_t WebDAVServer::handle_copy(httpd_req_t *req) {
     dst << src.rdbuf();
     src.close();
     dst.close();
+    httpd_resp_set_status(req, "201 Created");
     httpd_resp_send(req, "Resource copied", -1);
   } else {
+    ESP_LOGE(TAG, "Failed to copy %s to %s (errno: %d)", filepath.c_str(), dest_filepath.c_str(), errno);
     httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Cannot copy resource");
   }
 

--- a/esphome/components/webdav_server/webdav_server.h
+++ b/esphome/components/webdav_server/webdav_server.h
@@ -62,6 +62,7 @@ class WebDAVServer : public Component {
   bool authenticate(const std::string &auth_header);
   std::string uri_to_filepath(const std::string &uri);
   std::string url_decode(const std::string &src);
+  std::string extract_path_from_url(const std::string &url);
   std::string generate_prop_xml(const std::string &href, bool is_directory, time_t modified, size_t size);
   std::vector<std::string> list_dir(const std::string &path);
 


### PR DESCRIPTION
…nation header

WebDAV clients send full URLs in the Destination header (e.g., "http://192.168.1.212:81/usb/file.txt" instead of just "/usb/file.txt").

Added extract_path_from_url() helper function to:
- Detect full URLs (http:// or https://)
- Extract only the path portion
- Return unchanged if not a URL

Updated handle_copy() and handle_move() to:
- Use extract_path_from_url() before uri_to_filepath()
- Add comprehensive debug logging
- Set proper HTTP status codes (201 Created)
- Log errors with errno

This fixes copy/move operations failing with "Path not found" errors when clients use absolute URLs in the Destination header.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
