### PR TITLE
[webdav_server] Fix handler registration order - status before wildcards

### DIFF
--- a/esphome/components/webdav_server/webdav_server.cpp
+++ b/esphome/components/webdav_server/webdav_server.cpp
@@ -131,6 +131,16 @@ bool WebDAVServer::start_server() {
 
   esp_err_t err;
 
+  // Register specific routes BEFORE wildcard routes!
+  // Status endpoint must be registered before GET wildcard
+  err = httpd_register_uri_handler(this->server_, &status_handler);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register STATUS handler: %s", esp_err_to_name(err));
+    httpd_stop(this->server_);
+    return false;
+  }
+  ESP_LOGD(TAG, "Registered STATUS handler");
+
   err = httpd_register_uri_handler(this->server_, &options_handler);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to register OPTIONS handler: %s", esp_err_to_name(err));
@@ -194,14 +204,6 @@ bool WebDAVServer::start_server() {
     return false;
   }
   ESP_LOGD(TAG, "Registered COPY handler");
-
-  err = httpd_register_uri_handler(this->server_, &status_handler);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to register STATUS handler: %s", esp_err_to_name(err));
-    httpd_stop(this->server_);
-    return false;
-  }
-  ESP_LOGD(TAG, "Registered STATUS handler");
 
   ESP_LOGI(TAG, "All handlers registered successfully");
   return true;


### PR DESCRIPTION
CRITICAL FIX: Status handler must be registered BEFORE GET wildcard handler!

Problem: ESP-IDF httpd checks handlers in registration order. The GET wildcard handler (/*) was registered before the status handler (/status), so ALL GET requests to /status were caught by the wildcard handler, which tried to interpret "/status" as a file path.

This broke WebDAV connections completely as requests would fail.

Solution: Register specific routes BEFORE wildcard routes:
1. STATUS (/status) - specific route first
2. OPTIONS (/*), GET (/*), etc. - wildcards after

Also removed duplicate status handler registration at the end.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
