### PR TITLE
[webdav_server] Convert COPY and cross-mount MOVE to synchronous oper…

### DIFF
--- a/esphome/components/webdav_server/webdav_server.cpp
+++ b/esphome/components/webdav_server/webdav_server.cpp
@@ -56,7 +56,7 @@ bool WebDAVServer::start_server() {
   config.send_wait_timeout = 60;
   config.lru_purge_enable = true;
   config.max_resp_headers = 32;
-  config.max_open_sockets = 7;
+  config.max_open_sockets = 3;  // Reduced from 7 to 3 for synchronous operation mode
   config.uri_match_fn = httpd_uri_match_wildcard;  // CRITICAL: Enable wildcard URI matching for "/*" patterns
 
   esp_err_t ret = httpd_start(&this->server_, &config);
@@ -954,10 +954,10 @@ esp_err_t WebDAVServer::handle_move(httpd_req_t *req) {
     return ESP_OK;
   }
 
-  // If rename fails with EXDEV (cross-device), fall back to copy+delete
+  // If rename fails with EXDEV (cross-device), fall back to synchronous copy+delete
   ESP_LOGI(TAG, "rename() failed with errno=%d (EXDEV=%d)", rename_errno, EXDEV);
   if (rename_errno == EXDEV) {
-    ESP_LOGI(TAG, "Cross-mount move detected, using copy+delete fallback");
+    ESP_LOGI(TAG, "Cross-mount move detected, using synchronous copy+delete fallback");
 
     if (S_ISDIR(src_stat.st_mode)) {
       ESP_LOGE(TAG, "Cross-mount directory move not supported: %s", filepath.c_str());
@@ -965,45 +965,18 @@ esp_err_t WebDAVServer::handle_move(httpd_req_t *req) {
       return ESP_OK;
     }
 
-#ifdef USE_ESP32
-    // Create operation tracking
-    std::string op_id = server->create_operation_id();
-    OperationState op_state{
-        op_id, "move", filepath, dest_filepath, src_stat.st_size, 0, OperationStatus::IN_PROGRESS, esphome::millis(),
-        ""};
-    server->operations_.push_back(op_state);
-    server->cleanup_old_operations();
+    // Perform synchronous cross-mount move (blocks this client until complete)
+    ESP_LOGI(TAG, "Starting synchronous cross-mount move: %s -> %s (%zu bytes)", filepath.c_str(), dest_filepath.c_str(),
+             (size_t) src_stat.st_size);
 
-    // Spawn async task for cross-mount move
-    auto *task_params = new MoveTaskParams{server, op_id, filepath, dest_filepath, src_stat.st_size};
-
-    BaseType_t task_created = xTaskCreate(WebDAVServer::move_task, "webdav_move", 8192, task_params, 1, nullptr);
-
-    if (task_created == pdPASS) {
-      ESP_LOGI(TAG, "Cross-mount move task created [%s], responding to client", op_id.c_str());
-
-      // Return operation ID to client for status tracking
-      std::string response =
-          "{\"operation_id\":\"" + op_id + "\",\"status_url\":\"" + server->url_prefix_ + "/status?op_id=" + op_id + "\"}";
-
-      httpd_resp_set_type(req, "application/json");
-      httpd_resp_set_status(req, "202 Accepted");
-      httpd_resp_send(req, response.c_str(), response.length());
-    } else {
-      ESP_LOGE(TAG, "Failed to create move task");
-      server->update_operation_status(op_id, OperationStatus::FAILED, "Failed to create task");
-      delete task_params;
-      httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to start move operation");
-    }
-#else
-    // Non-ESP32: Perform synchronous move
     if (server->perform_file_move(filepath, dest_filepath, src_stat.st_size)) {
+      ESP_LOGI(TAG, "Cross-mount move completed successfully");
       httpd_resp_set_status(req, "201 Created");
       httpd_resp_send(req, "Resource moved", -1);
     } else {
+      ESP_LOGE(TAG, "Cross-mount move failed");
       httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Move failed");
     }
-#endif
   } else {
     // Other rename error
     ESP_LOGE(TAG, "Failed to move %s to %s (errno: %d, %s)", filepath.c_str(), dest_filepath.c_str(), rename_errno,
@@ -1046,43 +1019,18 @@ esp_err_t WebDAVServer::handle_copy(httpd_req_t *req) {
     return ESP_OK;
   }
 
-#ifdef USE_ESP32
-  // Create operation tracking
-  std::string op_id = server->create_operation_id();
-  OperationState op_state{
-      op_id, "copy", filepath, dest_filepath, src_stat.st_size, 0, OperationStatus::IN_PROGRESS, esphome::millis(), ""};
-  server->operations_.push_back(op_state);
-  server->cleanup_old_operations();
+  // Perform synchronous copy (blocks this client until complete)
+  ESP_LOGI(TAG, "Starting synchronous copy: %s -> %s (%zu bytes)", filepath.c_str(), dest_filepath.c_str(),
+           (size_t) src_stat.st_size);
 
-  // Spawn async task for file copy
-  auto *task_params = new CopyTaskParams{server, op_id, filepath, dest_filepath, src_stat.st_size};
-
-  BaseType_t task_created = xTaskCreate(WebDAVServer::copy_task, "webdav_copy", 8192, task_params, 1, nullptr);
-
-  if (task_created == pdPASS) {
-    ESP_LOGI(TAG, "Copy task created [%s], responding to client", op_id.c_str());
-
-    // Return operation ID to client for status tracking
-    std::string response =
-        "{\"operation_id\":\"" + op_id + "\",\"status_url\":\"" + server->url_prefix_ + "/status?op_id=" + op_id + "\"}";
-
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_status(req, "202 Accepted");
-    httpd_resp_send(req, response.c_str(), response.length());
-  } else {
-    ESP_LOGE(TAG, "Failed to create copy task");
-    delete task_params;
-    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to start copy operation");
-  }
-#else
-  // Non-ESP32: Perform synchronous copy
   if (server->perform_file_copy(filepath, dest_filepath, src_stat.st_size)) {
+    ESP_LOGI(TAG, "Copy completed successfully");
     httpd_resp_set_status(req, "201 Created");
     httpd_resp_send(req, "Resource copied", -1);
   } else {
+    ESP_LOGE(TAG, "Copy failed");
     httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Copy failed");
   }
-#endif
 
   return ESP_OK;
 }


### PR DESCRIPTION
…ations

This change removes async operation handling in favor of synchronous execution for better WebDAV client compatibility.

Changes:
- Made handle_copy() fully synchronous (blocks client until complete)
- Made cross-mount handle_move() synchronous (blocks client until complete)
- Reduced max_open_sockets from 7 to 3 (sufficient for realistic home use)

Rationale:
Standard WebDAV clients (MX Explorer, WinSCP) don't understand async responses with JSON. They expect synchronous behavior where 201 Created means the operation is done. With async, clients received 202 Accepted and refreshed directory listings too early, before files were ready.

Impact:
- Synchronous operations only block the individual client's socket
- Other clients can still work in parallel (up to 3 concurrent)
- Main ESP loop and other components unaffected
- Same-filesystem operations still use atomic rename()
- Leaves resources for web_server on separate port

The async task infrastructure (OperationState, status endpoint) remains for potential future use or removal in next commit.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
