### PR TITLE
[webdav_server] Add stall detection for file transfers instead of fix…

### DIFF
--- a/esphome/components/webdav_server/webdav_server.cpp
+++ b/esphome/components/webdav_server/webdav_server.cpp
@@ -52,11 +52,11 @@ bool WebDAVServer::start_server() {
   config.ctrl_port = this->port_ + 1000;
   config.max_uri_handlers = 20;
   config.stack_size = 8192;
-  config.recv_wait_timeout = 60;
-  config.send_wait_timeout = 60;
+  config.recv_wait_timeout = 7200;  // 2 hours - stall detection handles actual failures
+  config.send_wait_timeout = 7200;  // 2 hours - stall detection handles actual failures
   config.lru_purge_enable = true;
   config.max_resp_headers = 32;
-  config.max_open_sockets = 3;  // Reduced from 7 to 3 for synchronous operation mode
+  config.max_open_sockets = 3;  // 3 concurrent clients for synchronous operation mode
   config.uri_match_fn = httpd_uri_match_wildcard;  // CRITICAL: Enable wildcard URI matching for "/*" patterns
 
   esp_err_t ret = httpd_start(&this->server_, &config);
@@ -767,7 +767,7 @@ void WebDAVServer::cleanup_old_operations() {
                           this->operations_.end());
 }
 
-// Helper function: Perform file copy operation (used by both sync and async paths)
+// Helper function: Perform file copy operation with stall detection
 bool WebDAVServer::perform_file_copy(const std::string &src_path, const std::string &dst_path, off_t file_size,
                                      const std::string &operation_id) {
   FILE *src = fopen(src_path.c_str(), "rb");
@@ -789,6 +789,11 @@ bool WebDAVServer::perform_file_copy(const std::string &src_path, const std::str
   bool copy_success = true;
   bool read_error = false;
 
+  // Stall detection: check destination file size every 5 seconds
+  uint32_t last_check_time = millis();
+  size_t last_check_size = 0;
+  uint32_t last_growth_time = millis();
+
   ESP_LOGI(TAG, "Starting file copy: %s -> %s (size: %lld bytes)", src_path.c_str(), dst_path.c_str(),
            (long long) file_size);
 
@@ -806,10 +811,29 @@ bool WebDAVServer::perform_file_copy(const std::string &src_path, const std::str
       update_operation_progress(operation_id, total_copied);
     }
 
-    // Log progress for large files
-    if (total_copied % (FILE_BUFFER_SIZE * 64) == 0) {
-      ESP_LOGD(TAG, "Copy progress: %zu / %lld bytes (%.1f%%)", total_copied, (long long) file_size,
-               (total_copied * 100.0) / file_size);
+    // Stall detection: check every 5 seconds
+    uint32_t now = millis();
+    if (now - last_check_time >= 5000) {
+      // Flush to ensure file size is current
+      fflush(dst);
+
+      // Check destination file size
+      struct stat dst_stat;
+      if (stat(dst_path.c_str(), &dst_stat) == 0) {
+        if (dst_stat.st_size > (off_t) last_check_size) {
+          // File is growing - reset stall timer
+          last_growth_time = now;
+          last_check_size = dst_stat.st_size;
+          ESP_LOGD(TAG, "Copy progress: %zu / %lld bytes (%.1f%%)", total_copied, (long long) file_size,
+                   (total_copied * 100.0) / file_size);
+        } else if (now - last_growth_time >= 15000) {
+          // No growth for 15 seconds - stalled!
+          ESP_LOGE(TAG, "File copy stalled (no progress for 15s at %zu bytes)", total_copied);
+          copy_success = false;
+          break;
+        }
+      }
+      last_check_time = now;
     }
   }
 


### PR DESCRIPTION
…ed timeout

Implement dynamic stall detection for COPY/MOVE operations:
- Check destination file size every 5 seconds during transfer
- If file size hasn't grown for 15 seconds → operation failed (stalled)
- If file is growing → continue indefinitely until complete

HTTP timeout increased to 7200s (2 hours) as a backstop, but stall detection is the primary failure mechanism.

Rationale:
- Supports transfers of any size (up to 4GB on FAT32)
- At ~1MB/s average speed, 4GB = ~68 minutes transfer time
- No reasonable fixed timeout exists for this range
- Stall detection catches actual failures (USB disconnected, SD error) within 15 seconds regardless of file size
- Multiple clients still work in parallel via HTTP server's socket pool

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
