### PR TITLE
[webdav_server] Fix stall detection - track copy progress instead of …

### DIFF
--- a/esphome/components/webdav_server/webdav_server.cpp
+++ b/esphome/components/webdav_server/webdav_server.cpp
@@ -789,10 +789,10 @@ bool WebDAVServer::perform_file_copy(const std::string &src_path, const std::str
   bool copy_success = true;
   bool read_error = false;
 
-  // Stall detection: check destination file size every 5 seconds
+  // Stall detection: check if copy loop is progressing
   uint32_t last_check_time = millis();
-  size_t last_check_size = 0;
-  uint32_t last_growth_time = millis();
+  size_t last_check_copied = 0;
+  uint32_t last_progress_time = millis();
 
   ESP_LOGI(TAG, "Starting file copy: %s -> %s (size: %lld bytes)", src_path.c_str(), dst_path.c_str(),
            (long long) file_size);
@@ -811,27 +811,20 @@ bool WebDAVServer::perform_file_copy(const std::string &src_path, const std::str
       update_operation_progress(operation_id, total_copied);
     }
 
-    // Stall detection: check every 5 seconds
+    // Stall detection: check every 5 seconds if bytes copied is increasing
     uint32_t now = millis();
     if (now - last_check_time >= 5000) {
-      // Flush to ensure file size is current
-      fflush(dst);
-
-      // Check destination file size
-      struct stat dst_stat;
-      if (stat(dst_path.c_str(), &dst_stat) == 0) {
-        if (dst_stat.st_size > (off_t) last_check_size) {
-          // File is growing - reset stall timer
-          last_growth_time = now;
-          last_check_size = dst_stat.st_size;
-          ESP_LOGD(TAG, "Copy progress: %zu / %lld bytes (%.1f%%)", total_copied, (long long) file_size,
-                   (total_copied * 100.0) / file_size);
-        } else if (now - last_growth_time >= 15000) {
-          // No growth for 15 seconds - stalled!
-          ESP_LOGE(TAG, "File copy stalled (no progress for 15s at %zu bytes)", total_copied);
-          copy_success = false;
-          break;
-        }
+      if (total_copied > last_check_copied) {
+        // Copy is progressing - reset stall timer
+        last_progress_time = now;
+        last_check_copied = total_copied;
+        ESP_LOGD(TAG, "Copy progress: %zu / %lld bytes (%.1f%%)", total_copied, (long long) file_size,
+                 (total_copied * 100.0) / file_size);
+      } else if (now - last_progress_time >= 15000) {
+        // No progress for 15 seconds - stalled!
+        ESP_LOGE(TAG, "File copy stalled (no progress for 15s at %zu bytes)", total_copied);
+        copy_success = false;
+        break;
       }
       last_check_time = now;
     }


### PR DESCRIPTION
…disk size

Changed stall detection from checking disk file size to tracking bytes copied in memory (total_copied variable).

Issue: fflush() doesn't guarantee immediate disk sync on FAT32, so stat() would show no size change even though fwrite() was succeeding. This caused false stall detection.

Fix: Track if total_copied is increasing every 5 seconds. If the copy loop is making progress (fread/fwrite working), total_copied grows. Only trigger stall if total_copied hasn't increased for 15 seconds, which indicates the copy loop itself is stuck.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
