### PR TITLE
Fix API URL construction to work from subdirectories

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -533,6 +533,8 @@ std::string HttpFileServer::generate_html_footer() {
   </div>
 </div>
 <script>
+// API base path for this file server instance
+const API_BASE = ')" + this->url_prefix_ + R"(';
 let progressPollInterval = null;
 
 function showProgressModal(operation, source, destination) {
@@ -580,7 +582,7 @@ function formatTime(ms) {
 }
 
 function pollProgress() {
-  fetch(window.location.pathname + 'api/progress')
+  fetch(API_BASE + '/api/progress')
     .then(response => response.json())
     .then(data => {
       if (!data.in_progress) {
@@ -656,7 +658,7 @@ function copy_file(source) {
   // Show progress modal
   showProgressModal('copy', source, destination);
 
-  fetch(window.location.pathname + 'api/copy', {
+  fetch(API_BASE + '/api/copy', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({source: source, destination: destination})
@@ -684,7 +686,7 @@ function move_file(source) {
   // Show progress modal
   showProgressModal('move', source, destination);
 
-  fetch(window.location.pathname + 'api/move', {
+  fetch(API_BASE + '/api/move', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({source: source, destination: destination})
@@ -710,7 +712,7 @@ function rename_file(source) {
   const newName = prompt('Enter new name:', currentName);
   if (!newName || newName === currentName) return;
 
-  fetch(window.location.pathname + 'api/rename', {
+  fetch(API_BASE + '/api/rename', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({source: source, name: newName})
@@ -732,7 +734,7 @@ function create_directory() {
 
   const fullPath = window.location.pathname.replace(/\/$/, '') + '/' + name;
 
-  fetch(window.location.pathname + 'api/mkdir', {
+  fetch(API_BASE + '/api/mkdir', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({name: fullPath})


### PR DESCRIPTION
The frontend JavaScript was constructing API URLs relative to the current path (window.location.pathname), which caused "Method Not Allowed" errors when browsing subdirectories.

For example, if browsing /files/subdir/, the code would try to call /files/subdir/api/progress instead of /files/api/progress.

Fix:
- Inject url_prefix as API_BASE constant into JavaScript
- Update all fetch() calls to use API_BASE + '/api/endpoint'
- This ensures API calls always go to the correct base path regardless of which directory the user is currently browsing

Affected endpoints: /api/progress, /api/copy, /api/move, /api/rename, /api/mkdir

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
