### PR TITLE
Fix progress polling to start before operation completes

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -619,8 +619,8 @@ function startProgressPolling() {
   }
   // Poll every 500ms
   progressPollInterval = setInterval(pollProgress, 500);
-  // Also poll immediately
-  pollProgress();
+  // First poll after 250ms delay to give backend time to start tracking
+  setTimeout(pollProgress, 250);
 }
 
 function delete_file(path) {
@@ -655,8 +655,9 @@ function copy_file(source) {
   const destination = prompt('Enter destination path:', source + '.copy');
   if (!destination) return;
 
-  // Show progress modal
+  // Show progress modal and start polling immediately
   showProgressModal('copy', source, destination);
+  startProgressPolling();
 
   fetch(API_BASE + '/api/copy', {
     method: 'POST',
@@ -665,14 +666,12 @@ function copy_file(source) {
   })
     .then(response => response.json())
     .then(data => {
-      if (data.success) {
-        // Start polling for progress (for large files)
-        // Small files might complete instantly, so check progress first
-        startProgressPolling();
-      } else {
+      if (!data.success) {
+        // Operation failed - hide modal and show error
         hideProgressModal();
         alert('Copy failed: ' + (data.error || 'Unknown error'));
       }
+      // If successful, polling will continue and auto-close modal when done
     })
     .catch(error => {
       hideProgressModal();
@@ -683,8 +682,9 @@ function move_file(source) {
   const destination = prompt('Enter destination path:', source);
   if (!destination) return;
 
-  // Show progress modal
+  // Show progress modal and start polling immediately
   showProgressModal('move', source, destination);
+  startProgressPolling();
 
   fetch(API_BASE + '/api/move', {
     method: 'POST',
@@ -693,14 +693,12 @@ function move_file(source) {
   })
     .then(response => response.json())
     .then(data => {
-      if (data.success) {
-        // Start polling for progress (for large files)
-        // Small files might complete instantly, so check progress first
-        startProgressPolling();
-      } else {
+      if (!data.success) {
+        // Operation failed - hide modal and show error
         hideProgressModal();
         alert('Move failed: ' + (data.error || 'Unknown error'));
       }
+      // If successful, polling will continue and auto-close modal when done
     })
     .catch(error => {
       hideProgressModal();


### PR DESCRIPTION
The previous implementation had a critical timing issue:
- File operations (copy/move) are synchronous and block until complete
- Frontend was waiting for API response before starting to poll
- By the time polling started, operation was already finished
- Result: Progress bar stayed at 0% and never updated

Fix:
- Start polling IMMEDIATELY when showing the progress modal
- Don't wait for API response to start polling
- Add 250ms delay before first poll to give backend time to start tracking
- Polling now runs concurrently with the file operation
- Progress updates are visible in real-time

Flow now:
1. Show modal
2. Start polling (with 250ms initial delay)
3. Trigger copy/move API call (non-blocking from JS perspective)
4. Backend starts operation and tracks progress
5. Polling detects progress updates and updates UI
6. When operation completes, polling detects in_progress=false and closes modal

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
