### PR TITLE
Fix getParam() calls: remove unused boolean parameter

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -956,8 +956,8 @@ void HttpFileServer::handle_file_download(AsyncWebServerRequest *request, const 
 // API handlers
 void HttpFileServer::handle_api_copy(AsyncWebServerRequest *request) {
   // Get parameters from POST body
-  auto *source_param = request->getParam("source", true);
-  auto *dest_param = request->getParam("destination", true);
+  auto *source_param = request->getParam("source");
+  auto *dest_param = request->getParam("destination");
 
   if (!source_param || !dest_param) {
     ESP_LOGW(TAG, "Missing source or destination parameter");
@@ -993,8 +993,8 @@ void HttpFileServer::handle_api_copy(AsyncWebServerRequest *request) {
 
 void HttpFileServer::handle_api_move(AsyncWebServerRequest *request) {
   // Get parameters from POST body
-  auto *source_param = request->getParam("source", true);
-  auto *dest_param = request->getParam("destination", true);
+  auto *source_param = request->getParam("source");
+  auto *dest_param = request->getParam("destination");
 
   if (!source_param || !dest_param) {
     ESP_LOGW(TAG, "Missing source or destination parameter");
@@ -1030,8 +1030,8 @@ void HttpFileServer::handle_api_move(AsyncWebServerRequest *request) {
 
 void HttpFileServer::handle_api_rename(AsyncWebServerRequest *request) {
   // Get parameters from POST body
-  auto *source_param = request->getParam("source", true);
-  auto *name_param = request->getParam("name", true);
+  auto *source_param = request->getParam("source");
+  auto *name_param = request->getParam("name");
 
   if (!source_param || !name_param) {
     ESP_LOGW(TAG, "Missing source or name parameter");
@@ -1066,7 +1066,7 @@ void HttpFileServer::handle_api_rename(AsyncWebServerRequest *request) {
 
 void HttpFileServer::handle_api_mkdir(AsyncWebServerRequest *request) {
   // Get parameters from POST body
-  auto *name_param = request->getParam("name", true);
+  auto *name_param = request->getParam("name");
 
   if (!name_param) {
     ESP_LOGW(TAG, "Missing name parameter");


### PR DESCRIPTION
The web_server_idf implementation of getParam() only accepts one parameter (the parameter name), not two like ESPAsyncWebServer.

Signature:
  AsyncWebParameter *getParam(const std::string &name);

Fixed all API handlers:
- handle_api_copy: getParam("source") and getParam("destination")
- handle_api_move: getParam("source") and getParam("destination")
- handle_api_rename: getParam("source") and getParam("name")
- handle_api_mkdir: getParam("name")

This fixes the compilation errors.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
