### PR TITLE
Fix C++ compilation: remove quotes from comment and regex

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -664,7 +664,7 @@ function download_file(path, filename) {
     });
 }
 
-// Helper function to suggest a new filename with " (1)" before extension
+// Helper function to suggest a new filename with (1) appended before extension
 function suggestNewFilename(filepath) {
   const lastSlashIndex = filepath.lastIndexOf('/');
   const path = filepath.substring(0, lastSlashIndex + 1);
@@ -802,7 +802,10 @@ function create_directory() {
   if (!name || !name.trim()) return;
 
   // Create directory in current location
-  const currentPath = window.location.pathname.replace(/\/$/, '');
+  let currentPath = window.location.pathname;
+  if (currentPath.endsWith('/')) {
+    currentPath = currentPath.slice(0, -1);
+  }
   const fullPath = currentPath + '/' + name.trim();
 
   fetch(API_BASE + '/api/mkdir', {


### PR DESCRIPTION
- Changed comment to avoid ')"' sequence that prematurely closed raw string literal
- Replaced regex pattern with string methods to avoid backslash parsing issues
- Fixes compilation errors in file existence checking feature

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
