### PR TITLE
Fix remaining quoted sequences in JavaScript comments

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -725,7 +725,7 @@ async function copy_file(source) {
   if (exists) {
     const choice = confirm('File already exists. Click OK to overwrite, or Cancel to change the filename.');
     if (!choice) {
-      // User wants to change filename - suggest new name with " (1)"
+      // User wants to change filename - suggest new name with (1) appended
       const suggested = suggestNewFilename(destination);
       destination = prompt('Enter new destination path:', suggested);
       if (!destination) return;
@@ -767,7 +767,7 @@ async function move_file(source) {
   if (exists) {
     const choice = confirm('File already exists. Click OK to overwrite, or Cancel to change the filename.');
     if (!choice) {
-      // User wants to change filename - suggest new name with " (1)"
+      // User wants to change filename - suggest new name with (1) appended
       const suggested = suggestNewFilename(destination);
       destination = prompt('Enter new destination path:', suggested);
       if (!destination) return;


### PR DESCRIPTION
Remove all '" (1)"' patterns from comments that contain ')"' sequence. This was causing the C++ raw string literal to close prematurely.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
