### PR TITLE
Fix directory operations and protect mount points

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -990,9 +990,16 @@ std::string HttpFileServer::generate_file_row(const FileInfo &info, const std::s
     }
   } else {
     // Directory actions
-    if (this->deletion_enabled_) {
-      row += "<button class=\"delete\" onclick=\"delete_directory('" + info.path + "')\">Delete</button>";
+    if (!info.is_mount_point) {
+      // Rename button (not for mount points)
+      row += "<button onclick=\"rename_file('" + info.path + "')\">Rename</button>";
+      // Delete button (not for mount points)
+      if (this->deletion_enabled_) {
+        row += "<button class=\"delete\" onclick=\"delete_directory('" + file_uri + "')\">Delete</button>";
+      }
     }
+    // TODO: Add Mount/Unmount buttons for mount points
+    // This requires integration with usb_msc_host and sd_mmc_card automation actions
   }
 
   row += "</div></td></tr>";
@@ -1048,6 +1055,7 @@ void HttpFileServer::handle_directory_listing(AsyncWebServerRequest *request, co
         info.name = "root";
       info.path = mount.path;
       info.is_directory = true;
+      info.is_mount_point = true;
       info.size = 0;
       info.modified = 0;
 
@@ -1427,7 +1435,8 @@ void HttpFileServer::handle_api_dirisempty(AsyncWebServerRequest *request) {
     return;
   }
 
-  std::string dirpath = path_param->value().c_str();
+  std::string dir_uri = path_param->value().c_str();
+  std::string dirpath = this->uri_to_filepath(dir_uri);
 
   // Check if path exists and is a directory
   struct stat dir_stat;
@@ -1455,7 +1464,8 @@ void HttpFileServer::handle_api_dirinfo(AsyncWebServerRequest *request) {
     return;
   }
 
-  std::string dirpath = path_param->value().c_str();
+  std::string dir_uri = path_param->value().c_str();
+  std::string dirpath = this->uri_to_filepath(dir_uri);
 
   // Check if path exists and is a directory
   struct stat dir_stat;

--- a/esphome/components/http_file_server/http_file_server.h
+++ b/esphome/components/http_file_server/http_file_server.h
@@ -73,6 +73,7 @@ struct FileInfo {
   std::string name;
   std::string path;
   bool is_directory;
+  bool is_mount_point{false};
   size_t size;
   time_t modified;
 };


### PR DESCRIPTION
Directory delete/rename fixes:
- Fix delete_directory to use URI path (file_uri) instead of filesystem path
- Update /api/dirinfo and /api/dirisempty to convert URI to filesystem path
- Add rename buttons for directories (uses same rename logic as files)

Mount point protection:
- Add is_mount_point flag to FileInfo struct
- Mark storage mount points (usb, sdcard, etc.) as mount points
- Hide delete and rename buttons for mount points
- Add TODO comment for future Mount/Unmount automation integration

This prevents accidental deletion of mount points and enables directory renaming.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
