### PR TITLE
Add comprehensive canHandle logging for DELETE debugging

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -45,20 +45,23 @@ void HttpFileServer::dump_config() {
 bool HttpFileServer::canHandle(AsyncWebServerRequest *request) const {
   // Handle requests that start with our URL prefix
   std::string uri = request->url().c_str();
+  const char *method_name = (request->method() == HTTP_GET) ? "GET" : (request->method() == HTTP_POST) ? "POST" : (request->method() == HTTP_DELETE) ? "DELETE" : "OTHER";
+
+  ESP_LOGD(TAG, "canHandle called: %s %s (prefix: %s)", method_name, uri.c_str(), this->url_prefix_.c_str());
 
   // Check if URI starts with our prefix
   if (uri.find(this->url_prefix_) != 0) {
+    ESP_LOGD(TAG, "  -> NO: URI doesn't start with prefix");
     return false;
   }
 
   // We handle GET, POST, and DELETE methods
   if (request->method() == HTTP_GET || request->method() == HTTP_POST || request->method() == HTTP_DELETE) {
-    const char *method_name = (request->method() == HTTP_GET) ? "GET" : (request->method() == HTTP_POST) ? "POST" : "DELETE";
-    ESP_LOGD(TAG, "canHandle=true for %s %s", method_name, uri.c_str());
+    ESP_LOGI(TAG, "  -> YES: Will handle %s %s", method_name, uri.c_str());
     return true;
   }
 
-  ESP_LOGW(TAG, "canHandle=false - unsupported method for %s", uri.c_str());
+  ESP_LOGW(TAG, "  -> NO: Unsupported method %s", method_name);
   return false;
 }
 


### PR DESCRIPTION
Log every canHandle call with:
- HTTP method (GET/POST/DELETE/OTHER)
- Full URI and configured prefix
- Why the handler accepts or rejects the request

This will reveal if:
- DELETE requests reach our handler at all
- URI prefix matching is working correctly
- Another handler is intercepting DELETE requests

The logs will show the exact decision path for each request.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
