### PR TITLE
Fix DELETE 405 error and upload crash issues

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1306,22 +1306,29 @@ void HttpFileServer::handle_file_upload(AsyncWebServerRequest *request, const st
   // Get raw httpd_req_t to read POST body
   httpd_req_t *req = static_cast<httpd_req_t *>(*request);
   size_t remaining = request->contentLength();
-  const size_t BUFFER_SIZE = 4096;
+  const size_t BUFFER_SIZE = 2048;  // Smaller buffer to reduce stack usage
   uint8_t buffer[BUFFER_SIZE];
   bool success = true;
 
+  ESP_LOGI(TAG, "Reading upload data: %zu bytes total", remaining);
+
   // Read and write in chunks
   while (remaining > 0) {
+    // Feed the watchdog to prevent timeout on large uploads
+    App.feed_wdt();
+
     size_t to_read = (remaining > BUFFER_SIZE) ? BUFFER_SIZE : remaining;
     int received = httpd_req_recv(req, reinterpret_cast<char *>(buffer), to_read);
 
     if (received <= 0) {
-      ESP_LOGE(TAG, "Failed to receive data: %d", received);
+      ESP_LOGE(TAG, "Failed to receive data: %d (errno: %d)", received, errno);
       success = false;
       break;
     }
 
     size_t written = fwrite(buffer, 1, received, file);
+    fflush(file);  // Ensure data is written immediately
+
     if (written != static_cast<size_t>(received)) {
       ESP_LOGE(TAG, "Failed to write to file: wrote %zu of %d bytes", written, received);
       success = false;
@@ -1331,9 +1338,11 @@ void HttpFileServer::handle_file_upload(AsyncWebServerRequest *request, const st
     this->progress_.transferred_bytes += written;
     remaining -= received;
 
-    // Log progress every ~100KB
-    if (this->progress_.transferred_bytes % (100 * 1024) < BUFFER_SIZE) {
-      ESP_LOGD(TAG, "Upload progress: %zu / %zu bytes", this->progress_.transferred_bytes, this->progress_.total_bytes);
+    // Log progress every ~50KB
+    if (this->progress_.transferred_bytes % (50 * 1024) < BUFFER_SIZE) {
+      ESP_LOGD(TAG, "Upload progress: %zu / %zu bytes (%.1f%%)", this->progress_.transferred_bytes,
+               this->progress_.total_bytes,
+               (float) this->progress_.transferred_bytes / this->progress_.total_bytes * 100.0f);
     }
   }
 

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -127,7 +127,7 @@ void AsyncWebServer::begin() {
     httpd_register_uri_handler(this->server_, &handler_options);
 
     const httpd_uri_t handler_delete = {
-        .uri = "",
+        .uri = "/*",
         .method = HTTP_DELETE,
         .handler = AsyncWebServer::request_handler,
         .user_ctx = this,
@@ -157,6 +157,11 @@ esp_err_t AsyncWebServer::request_post_handler(httpd_req_t *r) {
       auto *server = static_cast<AsyncWebServer *>(r->user_ctx);
       return server->handle_multipart_upload_(r, content_type_char);
 #endif
+    } else if (stristr(content_type_char, "application/octet-stream") != nullptr) {
+      // Binary file upload - pass through to handlers via handleBody callback
+      // Don't consume the body here, let the handler read it directly
+      AsyncWebServerRequest req(r);
+      return static_cast<AsyncWebServer *>(r->user_ctx)->request_handler_(&req);
     } else {
       ESP_LOGW(TAG, "Unsupported content type for POST: %s", content_type_char);
       // fallback to get handler to support backward compatibility


### PR DESCRIPTION
1. Fix DELETE method registration:
   - Changed uri from "" to "/*" in DELETE handler
   - ESP-IDF requires wildcard pattern to match all paths
   - Empty string doesn't match any URLs, causing 405 errors

2. Fix upload crash:
   - Add proper application/octet-stream handling in web_server_idf
   - Reduce buffer size from 4KB to 2KB to reduce stack usage
   - Add App.feed_wdt() calls to prevent watchdog timeouts
   - Add fflush() after each write to ensure data persistence
   - Better error logging with errno
   - More frequent progress logging (every 50KB vs 100KB)

The DELETE handler now uses "/*" URI pattern like other handlers (GET, POST, OPTIONS) to properly match all paths in ESP-IDF.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
