### PR TITLE
Replace DELETE HTTP method with /api/delete POST endpoint

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -2,6 +2,7 @@
 #include "esphome/components/storage_host/storage_host.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/application.h"
 #include <fstream>
 #include <sstream>
 #include <sys/stat.h>
@@ -88,6 +89,15 @@ void HttpFileServer::handleRequest(AsyncWebServerRequest *request) {
   } else if (uri.find(this->url_prefix_ + "/api/mkdir") == 0 && request->method() == HTTP_POST) {
     ESP_LOGD(TAG, "API MKDIR endpoint hit, body_buffer size: %zu", this->body_buffer_.size());
     this->handle_api_mkdir(request);
+  } else if (uri.find(this->url_prefix_ + "/api/delete") == 0 && request->method() == HTTP_POST) {
+    ESP_LOGD(TAG, "API DELETE endpoint hit, body_buffer size: %zu", this->body_buffer_.size());
+    this->handle_api_delete(request);
+  } else if (uri.find(this->url_prefix_ + "/api/mount") == 0 && request->method() == HTTP_POST) {
+    ESP_LOGD(TAG, "API MOUNT endpoint hit, body_buffer size: %zu", this->body_buffer_.size());
+    this->handle_api_mount(request);
+  } else if (uri.find(this->url_prefix_ + "/api/unmount") == 0 && request->method() == HTTP_POST) {
+    ESP_LOGD(TAG, "API UNMOUNT endpoint hit, body_buffer size: %zu", this->body_buffer_.size());
+    this->handle_api_unmount(request);
   } else if (uri.find(this->url_prefix_ + "/api/exists") == 0 && request->method() == HTTP_GET) {
     this->handle_api_exists(request);
   } else if (uri.find(this->url_prefix_ + "/api/dirisempty") == 0 && request->method() == HTTP_GET) {
@@ -124,39 +134,6 @@ void HttpFileServer::handleRequest(AsyncWebServerRequest *request) {
       this->handle_file_upload(request, filename_param->value().c_str());
     } else {
       request->send(400, "text/plain", "Missing filename parameter");
-    }
-  } else if (request->method() == HTTP_DELETE) {
-    ESP_LOGI(TAG, "DELETE handler called for URI: %s", uri.c_str());
-
-    if (!this->deletion_enabled_) {
-      ESP_LOGW(TAG, "Deletion is disabled");
-      request->send(403, "application/json", "{\"error\":\"File deletion is disabled\"}");
-      return;
-    }
-
-    std::string filepath = this->uri_to_filepath(uri);
-    ESP_LOGI(TAG, "DELETE request - URI: %s -> Filepath: %s", uri.c_str(), filepath.c_str());
-
-    struct stat file_stat;
-    if (stat(filepath.c_str(), &file_stat) != 0) {
-      request->send(404, "application/json", "{\"error\":\"Path not found\"}");
-      return;
-    }
-
-    bool success = false;
-    if (S_ISDIR(file_stat.st_mode)) {
-      // Recursive directory deletion
-      ESP_LOGI(TAG, "Deleting directory recursively: %s", filepath.c_str());
-      success = this->recursive_delete_directory(filepath);
-    } else {
-      // Single file deletion
-      success = (remove(filepath.c_str()) == 0);
-    }
-
-    if (success) {
-      request->send(200, "application/json", "{\"success\":true}");
-    } else {
-      request->send(500, "application/json", "{\"error\":\"Failed to delete\"}");
     }
   } else {
     request->send(405, "application/json", "{\"error\":\"Method not allowed\"}");
@@ -725,7 +702,11 @@ function startProgressPolling() {
 
 function delete_file(path) {
   if (confirm('Are you sure you want to delete this file?')) {
-    fetch(path, {method: 'DELETE'})
+    fetch(API_BASE + '/api/delete', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: 'path=' + encodeURIComponent(path)
+    })
       .then(response => {
         if (!response.ok) {
           return response.text().then(text => {
@@ -789,8 +770,12 @@ async function delete_directory(path) {
       return;
     }
 
-    // Perform deletion
-    fetch(path, {method: 'DELETE'})
+    // Perform deletion using API endpoint
+    fetch(API_BASE + '/api/delete', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: 'path=' + encodeURIComponent(path)
+    })
       .then(response => {
         if (!response.ok) {
           return response.text().then(text => {
@@ -1597,6 +1582,103 @@ void HttpFileServer::handle_api_mkdir(AsyncWebServerRequest *request) {
   } else {
     ESP_LOGE(TAG, "Mkdir failed: %s (errno: %d, %s)", dir_path.c_str(), errno, strerror(errno));
     request->send(500, "application/json", "{\"error\":\"Mkdir operation failed\"}");
+  }
+}
+
+void HttpFileServer::handle_api_delete(AsyncWebServerRequest *request) {
+  if (!this->deletion_enabled_) {
+    ESP_LOGW(TAG, "Deletion is disabled");
+    request->send(403, "application/json", "{\"error\":\"File deletion is disabled\"}");
+    return;
+  }
+
+  // Get parameters from POST body
+  auto *path_param = request->getParam("path");
+
+  if (!path_param) {
+    ESP_LOGW(TAG, "Missing path parameter");
+    request->send(400, "application/json", "{\"error\":\"Missing path parameter\"}");
+    return;
+  }
+
+  std::string path_uri = path_param->value().c_str();
+
+  // Convert URI to filesystem path
+  std::string filepath = this->uri_to_filepath(path_uri);
+
+  ESP_LOGI(TAG, "API DELETE: URI=%s -> Path=%s", path_uri.c_str(), filepath.c_str());
+
+  // Check if path exists
+  struct stat file_stat;
+  if (stat(filepath.c_str(), &file_stat) != 0) {
+    request->send(404, "application/json", "{\"error\":\"Path not found\"}");
+    return;
+  }
+
+  bool success = false;
+  if (S_ISDIR(file_stat.st_mode)) {
+    // Recursive directory deletion
+    ESP_LOGI(TAG, "Deleting directory recursively: %s", filepath.c_str());
+    success = this->recursive_delete_directory(filepath);
+  } else {
+    // Single file deletion
+    ESP_LOGI(TAG, "Deleting file: %s", filepath.c_str());
+    success = (remove(filepath.c_str()) == 0);
+  }
+
+  if (success) {
+    request->send(200, "application/json", "{\"success\":true}");
+  } else {
+    ESP_LOGE(TAG, "Delete failed: %s (errno: %d, %s)", filepath.c_str(), errno, strerror(errno));
+    request->send(500, "application/json", "{\"error\":\"Delete operation failed\"}");
+  }
+}
+
+void HttpFileServer::handle_api_mount(AsyncWebServerRequest *request) {
+  // Get parameters from POST body
+  auto *device_param = request->getParam("device");
+  auto *mount_point_param = request->getParam("mount_point");
+
+  if (!device_param || !mount_point_param) {
+    ESP_LOGW(TAG, "Missing device or mount_point parameter");
+    request->send(400, "application/json", "{\"error\":\"Missing device or mount_point parameter\"}");
+    return;
+  }
+
+  std::string device = device_param->value().c_str();
+  std::string mount_point = mount_point_param->value().c_str();
+
+  ESP_LOGI(TAG, "API MOUNT: device=%s, mount_point=%s", device.c_str(), mount_point.c_str());
+
+  // Call storage_host to mount the device
+  if (this->storage_host_->mount_device(device.c_str(), mount_point.c_str())) {
+    request->send(200, "application/json", "{\"success\":true}");
+  } else {
+    ESP_LOGE(TAG, "Mount failed: %s at %s", device.c_str(), mount_point.c_str());
+    request->send(500, "application/json", "{\"error\":\"Mount operation failed\"}");
+  }
+}
+
+void HttpFileServer::handle_api_unmount(AsyncWebServerRequest *request) {
+  // Get parameters from POST body
+  auto *mount_point_param = request->getParam("mount_point");
+
+  if (!mount_point_param) {
+    ESP_LOGW(TAG, "Missing mount_point parameter");
+    request->send(400, "application/json", "{\"error\":\"Missing mount_point parameter\"}");
+    return;
+  }
+
+  std::string mount_point = mount_point_param->value().c_str();
+
+  ESP_LOGI(TAG, "API UNMOUNT: mount_point=%s", mount_point.c_str());
+
+  // Call storage_host to unmount the device
+  if (this->storage_host_->unmount_device(mount_point.c_str())) {
+    request->send(200, "application/json", "{\"success\":true}");
+  } else {
+    ESP_LOGE(TAG, "Unmount failed: %s", mount_point.c_str());
+    request->send(500, "application/json", "{\"error\":\"Unmount operation failed\"}");
   }
 }
 

--- a/esphome/components/http_file_server/http_file_server.h
+++ b/esphome/components/http_file_server/http_file_server.h
@@ -143,11 +143,14 @@ class HttpFileServer : public Component, public AsyncWebHandler {
 
   // Progress tracking for long operations
   struct {
-    std::string operation;  // "copy", "move", or "upload"
+    std::string operation;  // "copy", "move", "upload", or "delete"
     std::string source;
     std::string destination;
+    std::string current_file;  // Current file being processed (for delete operations)
     size_t total_bytes{0};
     size_t transferred_bytes{0};
+    int total_items{0};        // Total files/dirs to process (for delete operations)
+    int processed_items{0};    // Files/dirs processed so far (for delete operations)
     bool in_progress{false};
     uint32_t start_time{0};
   } progress_;
@@ -177,10 +180,13 @@ class HttpFileServer : public Component, public AsyncWebHandler {
   void handle_api_move(AsyncWebServerRequest *request);
   void handle_api_rename(AsyncWebServerRequest *request);
   void handle_api_mkdir(AsyncWebServerRequest *request);
+  void handle_api_delete(AsyncWebServerRequest *request);
   void handle_api_exists(AsyncWebServerRequest *request);
   void handle_api_dirisempty(AsyncWebServerRequest *request);
   void handle_api_dirinfo(AsyncWebServerRequest *request);
   void handle_api_progress(AsyncWebServerRequest *request);
+  void handle_api_mount(AsyncWebServerRequest *request);
+  void handle_api_unmount(AsyncWebServerRequest *request);
 
   // Directory helpers
   bool is_directory_empty(const std::string &path);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -125,14 +125,6 @@ void AsyncWebServer::begin() {
         .user_ctx = this,
     };
     httpd_register_uri_handler(this->server_, &handler_options);
-
-    const httpd_uri_t handler_delete = {
-        .uri = "/*",
-        .method = HTTP_DELETE,
-        .handler = AsyncWebServer::request_handler,
-        .user_ctx = this,
-    };
-    httpd_register_uri_handler(this->server_, &handler_delete);
   }
 }
 


### PR DESCRIPTION
Instead of fighting with ESP-IDF DELETE method registration, use a consistent POST-based API approach like the other operations.

Changes:
- Add /api/delete POST endpoint for file/directory deletion
- Add /api/mount and /api/unmount POST endpoints (stubs for future)
- Update JavaScript delete_file() and delete_directory() to use API
- Remove DELETE HTTP method handler from http_file_server
- Remove DELETE handler registration from web_server_idf
- Fix compilation error: include application.h for App.feed_wdt()
- Extend progress struct with current_file, total_items, processed_items for future deletion progress tracking

Benefits:
- No DELETE method registration issues
- Consistent with existing API patterns (copy, move, rename, mkdir)
- Works with all browsers/proxies (some block DELETE/PUT methods)
- Foundation for real-time deletion progress tracking

Mount/unmount endpoints are placeholders for future storage management.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
