### PR TITLE
[http_file_server] Fix download and upload progress issues

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1350,9 +1350,14 @@ void HttpFileServer::handle_file_download(AsyncWebServerRequest *request, const 
     // Get raw httpd_req_t
     httpd_req_t *req = static_cast<httpd_req_t *>(*request);
 
-    // Set response headers
+    // Set response headers including Content-Length so browser recognizes download
     httpd_resp_set_type(req, mime_type.c_str());
     httpd_resp_set_hdr(req, "Content-Disposition", ("attachment; filename=\"" + filename + "\"").c_str());
+
+    // Set Content-Length header - critical for browser to recognize download and show progress
+    char content_length_str[32];
+    snprintf(content_length_str, sizeof(content_length_str), "%zu", file_size);
+    httpd_resp_set_hdr(req, "Content-Length", content_length_str);
 
     // Allocate chunk buffer on heap
     auto buffer = std::make_unique<uint8_t[]>(CHUNK_SIZE);
@@ -1386,6 +1391,9 @@ void HttpFileServer::handle_file_download(AsyncWebServerRequest *request, const 
         ESP_LOGD(TAG, "Download progress: %zu / %zu bytes (%.1f%%)", total_sent, file_size,
                  (float) total_sent / file_size * 100.0f);
       }
+
+      // Yield briefly to other tasks to prevent blocking too long
+      vTaskDelay(1);  // 1 tick = ~10ms, allows other tasks to run
     }
 
     fclose(file);
@@ -1419,10 +1427,16 @@ void HttpFileServer::handle_file_upload(AsyncWebServerRequest *request, const st
 
   // Build full upload path
   std::string upload_path = Path::join(dir_path, filename);
-  ESP_LOGI(TAG, "Starting upload: %s", upload_path.c_str());
 
-  // Initialize progress tracking (thread-safe)
+  // Atomically check and set in_progress flag to prevent concurrent uploads
   portENTER_CRITICAL(&this->progress_mutex_);
+  if (this->progress_.in_progress) {
+    portEXIT_CRITICAL(&this->progress_mutex_);
+    ESP_LOGW(TAG, "Upload rejected: another operation is already in progress (%s)", upload_path.c_str());
+    request->send(409, "text/plain", "Another upload/copy/move is already in progress. Please wait.");
+    return;
+  }
+  // Set progress tracking immediately while still in critical section to prevent race
   this->progress_.operation = "upload";
   this->progress_.source = filename.c_str();
   this->progress_.destination = upload_path;
@@ -1431,6 +1445,9 @@ void HttpFileServer::handle_file_upload(AsyncWebServerRequest *request, const st
   this->progress_.in_progress = true;
   this->progress_.start_time = millis();
   portEXIT_CRITICAL(&this->progress_mutex_);
+
+  ESP_LOGI(TAG, "Starting upload: %s (%zu bytes, handler address: %p)", upload_path.c_str(),
+           request->contentLength(), (void *) this);
 
   // Open file for writing
   FILE *file = fopen(upload_path.c_str(), "wb");


### PR DESCRIPTION
Download fixes:
- Add Content-Length header for large file downloads Browsers need this to recognize downloads and show save dialog
- Add vTaskDelay(1) between 8KB chunks to yield to other tasks Prevents blocking web server and causing timeouts

Upload fixes:
- Add atomic check-and-set for in_progress flag Prevents race condition where multiple uploads could start simultaneously
- Move progress initialization into critical section Eliminates race where two requests pass the check before either sets the flag
- Add handler address to logging for debugging

This fixes:
- Downloads not triggering browser save dialog
- Download timeouts at ~22% progress
- Upload progress jumping backwards due to concurrent uploads
- Race conditions in concurrent operation detection

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
