### PR TITLE
[http_file_server] Fix Content-Disposition header using temporary string

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1319,6 +1319,7 @@ void HttpFileServer::handle_file_download(AsyncWebServerRequest *request, const 
   // Set content type based on file extension
   std::string mime_type = Path::mime_type(filepath);
   std::string filename = Path::file_name(filepath);
+  std::string content_disposition = "attachment; filename=\"" + filename + "\"";
 
   ESP_LOGI(TAG, "Starting file download: %s (size: %zu bytes)", filename.c_str(), file_size);
 
@@ -1340,7 +1341,7 @@ void HttpFileServer::handle_file_download(AsyncWebServerRequest *request, const 
     }
 
     AsyncWebServerResponse *response = request->beginResponse(200, mime_type.c_str(), content);
-    response->addHeader("Content-Disposition", ("attachment; filename=\"" + filename + "\"").c_str());
+    response->addHeader("Content-Disposition", content_disposition.c_str());
     request->send(response);
     ESP_LOGI(TAG, "Download sent: %zu bytes", bytes_read);
   } else {
@@ -1350,14 +1351,9 @@ void HttpFileServer::handle_file_download(AsyncWebServerRequest *request, const 
     // Get raw httpd_req_t
     httpd_req_t *req = static_cast<httpd_req_t *>(*request);
 
-    // Set response headers including Content-Length so browser recognizes download
+    // Set response headers - browser needs Content-Disposition to trigger download
     httpd_resp_set_type(req, mime_type.c_str());
-    httpd_resp_set_hdr(req, "Content-Disposition", ("attachment; filename=\"" + filename + "\"").c_str());
-
-    // Set Content-Length header - critical for browser to recognize download and show progress
-    char content_length_str[32];
-    snprintf(content_length_str, sizeof(content_length_str), "%zu", file_size);
-    httpd_resp_set_hdr(req, "Content-Length", content_length_str);
+    httpd_resp_set_hdr(req, "Content-Disposition", content_disposition.c_str());
 
     // Allocate chunk buffer on heap
     auto buffer = std::make_unique<uint8_t[]>(CHUNK_SIZE);


### PR DESCRIPTION
The Content-Disposition header was being set with a temporary string that was destroyed before being sent to the browser:

  response->addHeader("Content-Disposition",
    ("attachment; filename=\"" + filename + "\"").c_str());

The expression creates a temporary std::string, gets its c_str(), then destroys the string immediately - leaving a dangling pointer.

Fix: Store the header value in a local variable that stays in scope:
  std::string content_disposition = "attachment; filename=\"" + filename + "\"";
  response->addHeader("Content-Disposition", content_disposition.c_str());

Also removed Content-Length header from chunked downloads since it's incompatible with Transfer-Encoding: chunked (HTTP spec violation).

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
