### PR TITLE
[http_file_server] Fix upload progress tracking and compilation errors

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1428,8 +1428,8 @@ void HttpFileServer::handle_directory_listing(AsyncWebServerRequest *request, co
 
   html += this->generate_breadcrumb(filepath);
 
-  // Upload form
-  if (this->upload_enabled_) {
+  // Upload form (hidden for root directory)
+  if (this->upload_enabled_ && !is_virtual_root) {
     html += R"(<div class="upload-form">
       <form id="uploadForm" onsubmit="return handleUpload(event);">
         <input type="file" name="file" id="uploadFile" required>
@@ -1658,6 +1658,7 @@ void HttpFileServer::handle_file_upload(AsyncWebServerRequest *request, const st
   ESP_LOGI(TAG, "Reading upload data: %zu bytes total", remaining);
 
   // Read and write in chunks
+  size_t chunks_since_yield = 0;
   while (remaining > 0) {
     // Feed the watchdog to prevent timeout on large uploads
     App.feed_wdt();
@@ -1688,6 +1689,13 @@ void HttpFileServer::handle_file_upload(AsyncWebServerRequest *request, const st
     portEXIT_CRITICAL(&this->progress_mutex_);
 
     remaining -= received;
+    chunks_since_yield++;
+
+    // Yield to other tasks every 64 chunks (256KB - 1MB) to allow progress polling
+    if (chunks_since_yield >= 64) {
+      vTaskDelay(1);  // Brief yield to let other tasks run (including /api/progress requests)
+      chunks_since_yield = 0;
+    }
 
     // Log progress every ~50KB
     if (current_transferred % (50 * 1024) < BUFFER_SIZE) {
@@ -2092,49 +2100,7 @@ void HttpFileServer::handle_api_unmount(AsyncWebServerRequest *request) {
   this->deferred_mount_op_.schedule_time = millis() + 100;  // 100ms delay
 
   request->send(200, "application/json", "{\"success\":true}");
-  return;
-
-  // NOTE: The actual unmount happens in loop() - see perform_deferred_mount_op()
-  // This old immediate unmount code is commented out to prevent double-free crashes:
-  /*
-  ESP_LOGD(TAG, "  USB MSC devices in vector: %zu", this->usb_msc_devices_.size());
-  ESP_LOGD(TAG, "  SD MMC devices in vector: %zu", this->sd_mmc_devices_.size());
-
-  // Try to find matching USB MSC device and unmount
-#ifdef USE_USB_MSC_HOST
-  for (void *dev_ptr : this->usb_msc_devices_) {
-    auto *device = static_cast<usb_msc_host::USBMscDevice *>(dev_ptr);
-    ESP_LOGD(TAG, "  Checking USB MSC device with mount_path: %s", device->get_mount_path().c_str());
-    if (device->get_mount_path() == mount_point) {
-      device->unmount_device();
-      ESP_LOGI(TAG, "Successfully unmounted USB MSC device at %s", mount_point.c_str());
-      request->send(200, "application/json", "{\"success\":true}");
-      return;
-    }
-  }
-#endif
-
-  // Try SD MMC devices (check vector size instead of #ifdef to handle runtime registration)
-  if (!this->sd_mmc_devices_.empty()) {
-    for (void *dev_ptr : this->sd_mmc_devices_) {
-      ESP_LOGD(TAG, "  Iterating SD MMC devices, dev_ptr=%p", dev_ptr);
-#ifdef USE_SD_MMC_CARD
-      auto *device = static_cast<sd_mmc_card::SdMmc *>(dev_ptr);
-      ESP_LOGD(TAG, "  Checking SD MMC device with mount_path: %s", device->get_mount_path().c_str());
-      if (device->get_mount_path() == mount_point) {
-        device->unmount_card();
-        ESP_LOGI(TAG, "Successfully unmounted SD MMC device at %s", mount_point.c_str());
-        request->send(200, "application/json", "{\"success\":true}");
-        return;
-      }
-#else
-      ESP_LOGW(TAG, "  SD MMC device registered but USE_SD_MMC_CARD not defined - cannot access device");
-#endif
-    }
-  }
-
-  ESP_LOGW(TAG, "No device found for mount point: %s", mount_point.c_str());
-  request->send(404, "application/json", "{\"error\":\"Mount point not found\"}");
+  // NOTE: The actual unmount happens in loop() - see the loop() method
 }
 
 void HttpFileServer::handle_api_remount(AsyncWebServerRequest *request) {


### PR DESCRIPTION
This commit fixes multiple issues with file uploads:

1. **Fixed compilation error**: Removed unterminated comment block that was preventing compilation (line 2099).

2. **Fixed upload progress not showing in UX**: The upload loop was blocking the httpd task, preventing /api/progress polls from being answered. This caused:
   - Task watchdog timer errors
   - Progress modal timeouts
   - No progress updates visible in UI

   Solution: Added vTaskDelay(1) every 64 chunks (256KB-1MB) to yield to
   other tasks, allowing progress polls to be processed.

3. **Hide upload form in root directory**: Upload form is now hidden when viewing the root directory to prevent confusing users (uploads can't go to virtual root).

Changes:
- Added chunks_since_yield counter to upload loop
- Yield every 64 chunks with vTaskDelay(1)
- Cleaned up obsolete commented code
- Hide upload form when is_virtual_root is true

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
