### PR TITLE
[http_file_server] Remove .copy suffix and add live deletion logging

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1079,7 +1079,7 @@ async function performCopy(source, destination) {
 }
 
 async function copy_file(source) {
-  let destination = prompt('Enter destination path:', source + '.copy');
+  let destination = prompt('Enter destination path:', source);
   if (!destination) return;
 
   // Check if destination exists
@@ -1780,8 +1780,30 @@ bool HttpFileServer::recursive_delete_directory(const std::string &path) {
     return false;
   }
 
-  bool success = true;
+  // First pass: count the number of files in the directory
+  size_t file_count = 0;
   struct dirent *entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0) {
+      file_count++;
+    }
+  }
+  closedir(dir);
+
+  // Determine if we should log each file deletion
+  bool log_each_file = (file_count > 5);
+  if (log_each_file) {
+    ESP_LOGI(TAG, "Deleting directory with %zu files: %s (will log each file)", file_count, path.c_str());
+  }
+
+  // Second pass: actually delete the files
+  dir = opendir(path.c_str());
+  if (!dir) {
+    ESP_LOGE(TAG, "Cannot reopen directory for deletion: %s (errno: %d)", path.c_str(), errno);
+    return false;
+  }
+
+  bool success = true;
   while ((entry = readdir(dir)) != nullptr) {
     // Skip . and ..
     if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
@@ -1799,6 +1821,9 @@ bool HttpFileServer::recursive_delete_directory(const std::string &path) {
         }
       } else {
         // Delete file
+        if (log_each_file) {
+          ESP_LOGI(TAG, "Deleting file: %s", entry_path.c_str());
+        }
         if (remove(entry_path.c_str()) != 0) {
           ESP_LOGE(TAG, "Failed to delete file: %s (errno: %d, %s)", entry_path.c_str(), errno, strerror(errno));
           success = false;


### PR DESCRIPTION
This commit makes two UX improvements:

1. **Remove ".copy" suffix from copy operations**: When copying a file, the default destination path is now the same as the source path instead of appending ".copy". This provides a cleaner UX and matches the behavior of move operations.

2. **Add live file deletion logging for large directories**: When deleting directories with more than 5 files, each file deletion is now logged to help users track progress and debug issues. The function now:
   - Counts files in first pass
   - Logs "Deleting directory with N files" if > 5 files
   - Logs each individual file deletion during second pass

   This is especially useful for large directories where users want to see
   real-time progress in the logs.

Changes:
- Modified copy_file() prompt to use source path as default (line 1082)
- Added file counting pass to recursive_delete_directory() (lines 1783-1797)
- Added conditional logging for each file deletion (lines 1824-1826)

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
