### PR TITLE
[http_file_server] Fix compilation error - use get_header() instead o…

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -283,12 +283,14 @@ void HttpFileServer::handleRequest(AsyncWebServerRequest *request) {
     ESP_LOGD(TAG, "POST handler - upload for URI: %s", uri.c_str());
 
     // Check Content-Type to determine upload method
-    const char *content_type = request->contentType().c_str();
-    ESP_LOGD(TAG, "Content-Type: %s", content_type);
+    auto content_type = request->get_header("Content-Type");
+    if (content_type.has_value()) {
+      ESP_LOGD(TAG, "Content-Type: %s", content_type.value().c_str());
+    }
 
     // If multipart/form-data, let it pass through to handleUpload() callback
     // If application/octet-stream, use old synchronous handler
-    if (strstr(content_type, "multipart/form-data") != nullptr) {
+    if (content_type.has_value() && content_type.value().find("multipart/form-data") != std::string::npos) {
       // Multipart upload will be handled by handleUpload() callback - do nothing here
       ESP_LOGD(TAG, "Multipart upload detected - will be handled by handleUpload() callback");
     } else {


### PR DESCRIPTION
…f contentType()

Fixes compilation error:
  error: 'class AsyncWebServerRequest' has no member named 'contentType'

The AsyncWebServerRequest class doesn't have a contentType() method. Instead, use get_header("Content-Type") which returns optional<std::string>.

Changes:
- Replace request->contentType().c_str() with request->get_header("Content-Type")
- Check if header value exists with has_value() before accessing
- Use std::string::find() instead of strstr() for string comparison
- Properly handle optional<std::string> return type

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
