### PR TITLE
[http_file_server] Enable USE_WEBSERVER_OTA for multipart upload support

### DIFF
--- a/esphome/components/http_file_server/__init__.py
+++ b/esphome/components/http_file_server/__init__.py
@@ -70,6 +70,7 @@ CONFIG_SCHEMA = cv.All(
 @coroutine_with_priority(45.0)
 async def to_code(config):
     cg.add_define("USE_HTTP_FILE_SERVER")
+    cg.add_define("USE_WEBSERVER_OTA")  # Enable multipart upload support
 
     # Get web_server_base instance
     web_server_base_var = await cg.get_variable(


### PR DESCRIPTION
This enables multipart/form-data upload handling in the ESP-IDF AsyncWebServer. Without this define, multipart uploads fail with 'Unsupported content type'.

The web_server_idf.cpp only calls handle_multipart_upload_() when USE_WEBSERVER_OTA is defined (line 148-152).

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
