### PR TITLE
[http_file_server] Remove progress modal from downloads

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1042,23 +1042,17 @@ async function delete_directory(path) {
 }
 
 function download_file(path, filename) {
-  // Show progress modal
-  showProgressModal('download', filename, path);
-  startProgressPolling();
-
+  // Direct download without progress modal (blocking download prevents progress tracking)
   fetch(path)
     .then(response => response.blob())
     .then(blob => {
-      // Download complete - hide modal and trigger download
-      hideProgressModal();
       const link = document.createElement('a');
       link.href = URL.createObjectURL(blob);
       link.download = filename;
       link.click();
     })
     .catch(error => {
-      hideProgressModal();
-      alert('Error: ' + error);
+      alert('Download error: ' + error);
     });
 }
 


### PR DESCRIPTION
Downloads use blocking httpd_resp_send_chunk() which prevents /api/progress from being processed. This caused:
- Progress modal shows but never updates
- Timeout error blocks the page
- Download never starts because page is blocked

Fix: Remove progress modal from downloads entirely. Downloads now work directly without progress tracking.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
