### PR TITLE
[http_file_server] Fix POST API parameter parsing regression

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -2036,19 +2036,18 @@ bool HttpFileServer::is_mount_point_mounted(const std::string &mount_path) {
 
 // API handlers
 void HttpFileServer::handle_api_copy(AsyncWebServerRequest *request) {
-  // Get parameters from POST body
-  auto *source_param = request->getParam("source");
-  auto *dest_param = request->getParam("destination");
-
-  if (!source_param || !dest_param) {
+  // Parse parameters from POST body
+  ApiRequest req;
+  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
+      req.source.empty() || req.destination.empty()) {
     ESP_LOGW(TAG, "Missing source or destination parameter");
     request->send(400, "application/json", "{\"error\":\"Missing source or destination\"}");
     return;
   }
 
   // Convert URI paths to filesystem paths (strips URL prefix)
-  std::string source = this->uri_to_filepath(source_param->value().c_str());
-  std::string destination = this->uri_to_filepath(dest_param->value().c_str());
+  std::string source = this->uri_to_filepath(req.source);
+  std::string destination = this->uri_to_filepath(req.destination);
 
   ESP_LOGI(TAG, "API COPY: %s -> %s", source.c_str(), destination.c_str());
 
@@ -2084,19 +2083,18 @@ void HttpFileServer::handle_api_copy(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_move(AsyncWebServerRequest *request) {
-  // Get parameters from POST body
-  auto *source_param = request->getParam("source");
-  auto *dest_param = request->getParam("destination");
-
-  if (!source_param || !dest_param) {
+  // Parse parameters from POST body
+  ApiRequest req;
+  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
+      req.source.empty() || req.destination.empty()) {
     ESP_LOGW(TAG, "Missing source or destination parameter");
     request->send(400, "application/json", "{\"error\":\"Missing source or destination\"}");
     return;
   }
 
   // Convert URI paths to filesystem paths (strips URL prefix)
-  std::string source = this->uri_to_filepath(source_param->value().c_str());
-  std::string destination = this->uri_to_filepath(dest_param->value().c_str());
+  std::string source = this->uri_to_filepath(req.source);
+  std::string destination = this->uri_to_filepath(req.destination);
 
   ESP_LOGI(TAG, "API MOVE: %s -> %s", source.c_str(), destination.c_str());
 
@@ -2131,19 +2129,18 @@ void HttpFileServer::handle_api_move(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_rename(AsyncWebServerRequest *request) {
-  // Get parameters from POST body
-  auto *source_param = request->getParam("source");
-  auto *name_param = request->getParam("name");
-
-  if (!source_param || !name_param) {
+  // Parse parameters from POST body
+  ApiRequest req;
+  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
+      req.source.empty() || req.name.empty()) {
     ESP_LOGW(TAG, "Missing source or name parameter");
     request->send(400, "application/json", "{\"error\":\"Missing source or name\"}");
     return;
   }
 
   // Convert URI path to filesystem path (strips URL prefix)
-  std::string source = this->uri_to_filepath(source_param->value().c_str());
-  std::string new_name = name_param->value().c_str();
+  std::string source = this->uri_to_filepath(req.source);
+  std::string new_name = req.name;
 
   // Build new path (same directory, new name)
   std::string dir_path = source.substr(0, source.find_last_of('/'));
@@ -2168,16 +2165,16 @@ void HttpFileServer::handle_api_rename(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_mkdir(AsyncWebServerRequest *request) {
-  // Get parameters from POST body
-  auto *name_param = request->getParam("name");
-
-  if (!name_param) {
+  // Parse parameters from POST body
+  ApiRequest req;
+  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
+      req.name.empty()) {
     ESP_LOGW(TAG, "Missing name parameter");
     request->send(400, "application/json", "{\"error\":\"Missing directory name\"}");
     return;
   }
 
-  std::string dir_uri = name_param->value().c_str();
+  std::string dir_uri = req.name;
 
   // Convert URI to filesystem path
   std::string dir_path = this->uri_to_filepath(dir_uri);
@@ -2200,16 +2197,16 @@ void HttpFileServer::handle_api_delete(AsyncWebServerRequest *request) {
     return;
   }
 
-  // Get parameters from POST body
-  auto *path_param = request->getParam("path");
-
-  if (!path_param) {
+  // Parse parameters from POST body
+  ApiRequest req;
+  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
+      req.path.empty()) {
     ESP_LOGW(TAG, "Missing path parameter");
     request->send(400, "application/json", "{\"error\":\"Missing path parameter\"}");
     return;
   }
 
-  std::string path_uri = path_param->value().c_str();
+  std::string path_uri = req.path;
 
   // Convert URI to filesystem path
   std::string filepath = this->uri_to_filepath(path_uri);
@@ -2274,16 +2271,16 @@ void HttpFileServer::handle_api_delete(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_mount(AsyncWebServerRequest *request) {
-  // Get mount_point parameter
-  auto *mount_point_param = request->getParam("mount_point");
-
-  if (!mount_point_param) {
+  // Parse parameters from POST body
+  ApiRequest req;
+  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
+      req.mount_point.empty()) {
     ESP_LOGW(TAG, "Missing mount_point parameter");
     request->send(400, "application/json", "{\"error\":\"Missing mount_point parameter\"}");
     return;
   }
 
-  std::string mount_point = mount_point_param->value().c_str();
+  std::string mount_point = req.mount_point;
   ESP_LOGI(TAG, "API MOUNT: mount_point=%s (scheduling deferred mount)", mount_point.c_str());
 
   // Schedule deferred mount to happen in loop() after HTTP response completes
@@ -2297,16 +2294,16 @@ void HttpFileServer::handle_api_mount(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_unmount(AsyncWebServerRequest *request) {
-  // Get mount_point parameter
-  auto *mount_point_param = request->getParam("mount_point");
-
-  if (!mount_point_param) {
+  // Parse parameters from POST body
+  ApiRequest req;
+  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
+      req.mount_point.empty()) {
     ESP_LOGW(TAG, "Missing mount_point parameter");
     request->send(400, "application/json", "{\"error\":\"Missing mount_point parameter\"}");
     return;
   }
 
-  std::string mount_point = mount_point_param->value().c_str();
+  std::string mount_point = req.mount_point;
   ESP_LOGI(TAG, "API UNMOUNT: mount_point=%s (scheduling deferred unmount)", mount_point.c_str());
 
   // Schedule deferred unmount to happen in loop() after HTTP response completes
@@ -2320,16 +2317,16 @@ void HttpFileServer::handle_api_unmount(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_remount(AsyncWebServerRequest *request) {
-  // Get mount_point parameter
-  auto *mount_point_param = request->getParam("mount_point");
-
-  if (!mount_point_param) {
+  // Parse parameters from POST body
+  ApiRequest req;
+  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
+      req.mount_point.empty()) {
     ESP_LOGW(TAG, "Missing mount_point parameter");
     request->send(400, "application/json", "{\"error\":\"Missing mount_point parameter\"}");
     return;
   }
 
-  std::string mount_point = mount_point_param->value().c_str();
+  std::string mount_point = req.mount_point;
   ESP_LOGI(TAG, "API REMOUNT: mount_point=%s (scheduling deferred remount)", mount_point.c_str());
 
   // Schedule deferred remount to happen in loop() after HTTP response completes
@@ -2558,7 +2555,7 @@ void HttpFileServer::handle_api_dirinfo(AsyncWebServerRequest *request) {
 // Form data parsing helper
 bool HttpFileServer::parse_json_request(const uint8_t *body, size_t body_len, ApiRequest &req) {
   // Parse URL-encoded form data
-  // Format: source=/path/to/file&destination=/path/to/dest&name=newname
+  // Format: source=/path/to/file&destination=/path/to/dest&name=newname&path=/file&mount_point=/mnt&device=/dev/sda1
   std::string form_data((const char *) body, body_len);
 
   // Split by '&' to get key=value pairs
@@ -2584,13 +2581,20 @@ bool HttpFileServer::parse_json_request(const uint8_t *body, size_t body_len, Ap
         req.destination = value;
       } else if (key == "name") {
         req.name = value;
+      } else if (key == "path") {
+        req.path = value;
+      } else if (key == "mount_point") {
+        req.mount_point = value;
+      } else if (key == "device") {
+        req.device = value;
       }
     }
 
     pos = amp_pos + 1;
   }
 
-  return !req.source.empty() || !req.destination.empty() || !req.name.empty();
+  return !req.source.empty() || !req.destination.empty() || !req.name.empty() || !req.path.empty() ||
+         !req.mount_point.empty() || !req.device.empty();
 }
 
 // RAII wrapper for FILE* to ensure files are always closed

--- a/esphome/components/http_file_server/http_file_server.h
+++ b/esphome/components/http_file_server/http_file_server.h
@@ -266,6 +266,9 @@ class HttpFileServer : public Component, public AsyncWebHandler {
     std::string source;
     std::string destination;
     std::string name;
+    std::string path;
+    std::string mount_point;
+    std::string device;
   };
   bool parse_json_request(const uint8_t *body, size_t body_len, ApiRequest &req);
 


### PR DESCRIPTION
All POST API endpoints (delete, copy, move, rename, mkdir, mount, unmount, remount) were failing with "Missing [parameter] parameter" errors because AsyncWebServer's request->getParam() doesn't work with URL-encoded POST body data.

Root Cause:
- Frontend sends POST with URL-encoded body: 'path=/files/test.txt'
- handleBody() collects raw body into body_buffer_ but doesn't parse it
- API handlers call request->getParam("path") which returns nullptr
- getParam() only works for query strings and multipart form data

Fix:
1. Extended ApiRequest struct to include all required fields:
   - path (for delete operations)
   - mount_point (for mount/unmount/remount operations)
   - device (for mount operations, future use)

2. Updated parse_json_request() to parse all new fields from URL-encoded body

3. Modified all 8 API handlers to use parsed body_buffer_ instead of getParam():
   - handle_api_delete() - parse path from body
   - handle_api_copy() - parse source + destination from body
   - handle_api_move() - parse source + destination from body
   - handle_api_rename() - parse source + name from body
   - handle_api_mkdir() - parse name from body
   - handle_api_mount() - parse mount_point from body
   - handle_api_unmount() - parse mount_point from body
   - handle_api_remount() - parse mount_point from body

Note: Transfer functions (copy_task, move_task) are unchanged as requested.

Fixes error: "Error 500: Missing file parameter"

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
