### PR TITLE
[http_file_server] Fix API parameter parsing and upload regression

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -211,6 +211,16 @@ bool HttpFileServer::canHandle(AsyncWebServerRequest *request) const {
     return false;
   }
 
+  // For POST requests with multipart/form-data, return false so handleRequest() is not called
+  // (handleUpload() will handle these requests instead)
+  if (request->method() == HTTP_POST) {
+    auto content_type = request->get_header("Content-Type");
+    if (content_type.has_value() && content_type.value().find("multipart/form-data") != std::string::npos) {
+      ESP_LOGD(TAG, "  -> NO: Multipart upload will be handled by handleUpload() callback only");
+      return false;  // Let handleUpload() handle this, don't call handleRequest()
+    }
+  }
+
   // We handle GET, POST, and DELETE methods
   if (request->method() == HTTP_GET || request->method() == HTTP_POST || request->method() == HTTP_DELETE) {
     ESP_LOGI(TAG, "  -> YES: Will handle %s %s", method_name, uri.c_str());
@@ -2036,18 +2046,33 @@ bool HttpFileServer::is_mount_point_mounted(const std::string &mount_path) {
 
 // API handlers
 void HttpFileServer::handle_api_copy(AsyncWebServerRequest *request) {
-  // Parse parameters from POST body
-  ApiRequest req;
-  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
-      req.source.empty() || req.destination.empty()) {
+  // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
+  std::string source_uri, dest_uri;
+
+  auto *source_param = request->getParam("source", true);  // true = POST parameter
+  auto *dest_param = request->getParam("destination", true);
+
+  if (source_param && dest_param) {
+    source_uri = source_param->value().c_str();
+    dest_uri = dest_param->value().c_str();
+  } else {
+    // Fallback: parse from body_buffer_
+    ApiRequest req;
+    if (this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req)) {
+      source_uri = req.source;
+      dest_uri = req.destination;
+    }
+  }
+
+  if (source_uri.empty() || dest_uri.empty()) {
     ESP_LOGW(TAG, "Missing source or destination parameter");
     request->send(400, "application/json", "{\"error\":\"Missing source or destination\"}");
     return;
   }
 
   // Convert URI paths to filesystem paths (strips URL prefix)
-  std::string source = this->uri_to_filepath(req.source);
-  std::string destination = this->uri_to_filepath(req.destination);
+  std::string source = this->uri_to_filepath(source_uri);
+  std::string destination = this->uri_to_filepath(dest_uri);
 
   ESP_LOGI(TAG, "API COPY: %s -> %s", source.c_str(), destination.c_str());
 
@@ -2083,18 +2108,33 @@ void HttpFileServer::handle_api_copy(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_move(AsyncWebServerRequest *request) {
-  // Parse parameters from POST body
-  ApiRequest req;
-  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
-      req.source.empty() || req.destination.empty()) {
+  // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
+  std::string source_uri, dest_uri;
+
+  auto *source_param = request->getParam("source", true);  // true = POST parameter
+  auto *dest_param = request->getParam("destination", true);
+
+  if (source_param && dest_param) {
+    source_uri = source_param->value().c_str();
+    dest_uri = dest_param->value().c_str();
+  } else {
+    // Fallback: parse from body_buffer_
+    ApiRequest req;
+    if (this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req)) {
+      source_uri = req.source;
+      dest_uri = req.destination;
+    }
+  }
+
+  if (source_uri.empty() || dest_uri.empty()) {
     ESP_LOGW(TAG, "Missing source or destination parameter");
     request->send(400, "application/json", "{\"error\":\"Missing source or destination\"}");
     return;
   }
 
   // Convert URI paths to filesystem paths (strips URL prefix)
-  std::string source = this->uri_to_filepath(req.source);
-  std::string destination = this->uri_to_filepath(req.destination);
+  std::string source = this->uri_to_filepath(source_uri);
+  std::string destination = this->uri_to_filepath(dest_uri);
 
   ESP_LOGI(TAG, "API MOVE: %s -> %s", source.c_str(), destination.c_str());
 
@@ -2129,18 +2169,32 @@ void HttpFileServer::handle_api_move(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_rename(AsyncWebServerRequest *request) {
-  // Parse parameters from POST body
-  ApiRequest req;
-  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
-      req.source.empty() || req.name.empty()) {
+  // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
+  std::string source_uri, new_name;
+
+  auto *source_param = request->getParam("source", true);  // true = POST parameter
+  auto *name_param = request->getParam("name", true);
+
+  if (source_param && name_param) {
+    source_uri = source_param->value().c_str();
+    new_name = name_param->value().c_str();
+  } else {
+    // Fallback: parse from body_buffer_
+    ApiRequest req;
+    if (this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req)) {
+      source_uri = req.source;
+      new_name = req.name;
+    }
+  }
+
+  if (source_uri.empty() || new_name.empty()) {
     ESP_LOGW(TAG, "Missing source or name parameter");
     request->send(400, "application/json", "{\"error\":\"Missing source or name\"}");
     return;
   }
 
   // Convert URI path to filesystem path (strips URL prefix)
-  std::string source = this->uri_to_filepath(req.source);
-  std::string new_name = req.name;
+  std::string source = this->uri_to_filepath(source_uri);
 
   // Build new path (same directory, new name)
   std::string dir_path = source.substr(0, source.find_last_of('/'));
@@ -2165,16 +2219,25 @@ void HttpFileServer::handle_api_rename(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_mkdir(AsyncWebServerRequest *request) {
-  // Parse parameters from POST body
-  ApiRequest req;
-  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
-      req.name.empty()) {
+  // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
+  std::string dir_uri;
+
+  auto *name_param = request->getParam("name", true);  // true = POST parameter
+  if (name_param) {
+    dir_uri = name_param->value().c_str();
+  } else {
+    // Fallback: parse from body_buffer_
+    ApiRequest req;
+    if (this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req)) {
+      dir_uri = req.name;
+    }
+  }
+
+  if (dir_uri.empty()) {
     ESP_LOGW(TAG, "Missing name parameter");
     request->send(400, "application/json", "{\"error\":\"Missing directory name\"}");
     return;
   }
-
-  std::string dir_uri = req.name;
 
   // Convert URI to filesystem path
   std::string dir_path = this->uri_to_filepath(dir_uri);
@@ -2197,16 +2260,25 @@ void HttpFileServer::handle_api_delete(AsyncWebServerRequest *request) {
     return;
   }
 
-  // Parse parameters from POST body
-  ApiRequest req;
-  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
-      req.path.empty()) {
+  // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
+  std::string path_uri;
+
+  auto *path_param = request->getParam("path", true);  // true = POST parameter
+  if (path_param) {
+    path_uri = path_param->value().c_str();
+  } else {
+    // Fallback: parse from body_buffer_
+    ApiRequest req;
+    if (this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req)) {
+      path_uri = req.path;
+    }
+  }
+
+  if (path_uri.empty()) {
     ESP_LOGW(TAG, "Missing path parameter");
     request->send(400, "application/json", "{\"error\":\"Missing path parameter\"}");
     return;
   }
-
-  std::string path_uri = req.path;
 
   // Convert URI to filesystem path
   std::string filepath = this->uri_to_filepath(path_uri);
@@ -2271,16 +2343,25 @@ void HttpFileServer::handle_api_delete(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_mount(AsyncWebServerRequest *request) {
-  // Parse parameters from POST body
-  ApiRequest req;
-  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
-      req.mount_point.empty()) {
+  // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
+  std::string mount_point;
+
+  auto *mount_point_param = request->getParam("mount_point", true);  // true = POST parameter
+  if (mount_point_param) {
+    mount_point = mount_point_param->value().c_str();
+  } else {
+    // Fallback: parse from body_buffer_
+    ApiRequest req;
+    if (this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req)) {
+      mount_point = req.mount_point;
+    }
+  }
+
+  if (mount_point.empty()) {
     ESP_LOGW(TAG, "Missing mount_point parameter");
     request->send(400, "application/json", "{\"error\":\"Missing mount_point parameter\"}");
     return;
   }
-
-  std::string mount_point = req.mount_point;
   ESP_LOGI(TAG, "API MOUNT: mount_point=%s (scheduling deferred mount)", mount_point.c_str());
 
   // Schedule deferred mount to happen in loop() after HTTP response completes
@@ -2294,16 +2375,25 @@ void HttpFileServer::handle_api_mount(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_unmount(AsyncWebServerRequest *request) {
-  // Parse parameters from POST body
-  ApiRequest req;
-  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
-      req.mount_point.empty()) {
+  // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
+  std::string mount_point;
+
+  auto *mount_point_param = request->getParam("mount_point", true);  // true = POST parameter
+  if (mount_point_param) {
+    mount_point = mount_point_param->value().c_str();
+  } else {
+    // Fallback: parse from body_buffer_
+    ApiRequest req;
+    if (this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req)) {
+      mount_point = req.mount_point;
+    }
+  }
+
+  if (mount_point.empty()) {
     ESP_LOGW(TAG, "Missing mount_point parameter");
     request->send(400, "application/json", "{\"error\":\"Missing mount_point parameter\"}");
     return;
   }
-
-  std::string mount_point = req.mount_point;
   ESP_LOGI(TAG, "API UNMOUNT: mount_point=%s (scheduling deferred unmount)", mount_point.c_str());
 
   // Schedule deferred unmount to happen in loop() after HTTP response completes
@@ -2317,16 +2407,25 @@ void HttpFileServer::handle_api_unmount(AsyncWebServerRequest *request) {
 }
 
 void HttpFileServer::handle_api_remount(AsyncWebServerRequest *request) {
-  // Parse parameters from POST body
-  ApiRequest req;
-  if (!this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req) ||
-      req.mount_point.empty()) {
+  // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
+  std::string mount_point;
+
+  auto *mount_point_param = request->getParam("mount_point", true);  // true = POST parameter
+  if (mount_point_param) {
+    mount_point = mount_point_param->value().c_str();
+  } else {
+    // Fallback: parse from body_buffer_
+    ApiRequest req;
+    if (this->parse_json_request((const uint8_t *) this->body_buffer_.data(), this->body_buffer_.size(), req)) {
+      mount_point = req.mount_point;
+    }
+  }
+
+  if (mount_point.empty()) {
     ESP_LOGW(TAG, "Missing mount_point parameter");
     request->send(400, "application/json", "{\"error\":\"Missing mount_point parameter\"}");
     return;
   }
-
-  std::string mount_point = req.mount_point;
   ESP_LOGI(TAG, "API REMOUNT: mount_point=%s (scheduling deferred remount)", mount_point.c_str());
 
   // Schedule deferred remount to happen in loop() after HTTP response completes


### PR DESCRIPTION
This commit fixes two critical regressions:

1. **API Parameter Parsing (mkdir/copy/move/rename/delete/mount/unmount/remount)**
   - Root Cause: AsyncWebServer auto-parses URL-encoded POST bodies and makes parameters available via getParam(), NOT via handleBody()/body_buffer_
   - body_buffer_ is only filled for raw POST data (not URL-encoded)
   - Previous code only checked body_buffer_, which was empty for URL-encoded requests
   - Symptoms: "SyntaxError: Unexpected token 'M', 'Missing fi...' is not valid JSON"

   - Fix: Hybrid approach in all 8 API handlers:
     - Try getParam() first (for URL-encoded form data)
     - Fallback to body_buffer_ parsing (for raw POST data) - This ensures compatibility with both URL-encoded and raw POST requests

2. **Upload Regression (modal opens but no progress)**
   - Root Cause: canHandle() returned true for multipart-uploads, causing handleRequest() to be called in addition to handleUpload()
   - handleRequest() returned without sending a response, confusing AsyncWebServer
   - This caused handleUpload() to be called twice with index==0

   - Fix: Exclude multipart/form-data from canHandle():
     - Check Content-Type header in canHandle()
     - Return false for multipart-uploads so handleRequest() is NOT called - Only handleUpload() callback will handle multipart-uploads - This prevents double-initialization and allows proper upload progress tracking

All API endpoints now work correctly with URL-encoded POST bodies, and uploads work with proper progress tracking.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
