### PR TITLE
[http_file_server] Fix getParam() calls for ESP-IDF compatibility

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -2049,8 +2049,8 @@ void HttpFileServer::handle_api_copy(AsyncWebServerRequest *request) {
   // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
   std::string source_uri, dest_uri;
 
-  auto *source_param = request->getParam("source", true);  // true = POST parameter
-  auto *dest_param = request->getParam("destination", true);
+  auto *source_param = request->getParam("source");  // POST parameter
+  auto *dest_param = request->getParam("destination");
 
   if (source_param && dest_param) {
     source_uri = source_param->value().c_str();
@@ -2111,8 +2111,8 @@ void HttpFileServer::handle_api_move(AsyncWebServerRequest *request) {
   // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
   std::string source_uri, dest_uri;
 
-  auto *source_param = request->getParam("source", true);  // true = POST parameter
-  auto *dest_param = request->getParam("destination", true);
+  auto *source_param = request->getParam("source");  // POST parameter
+  auto *dest_param = request->getParam("destination");
 
   if (source_param && dest_param) {
     source_uri = source_param->value().c_str();
@@ -2172,8 +2172,8 @@ void HttpFileServer::handle_api_rename(AsyncWebServerRequest *request) {
   // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
   std::string source_uri, new_name;
 
-  auto *source_param = request->getParam("source", true);  // true = POST parameter
-  auto *name_param = request->getParam("name", true);
+  auto *source_param = request->getParam("source");  // POST parameter
+  auto *name_param = request->getParam("name");
 
   if (source_param && name_param) {
     source_uri = source_param->value().c_str();
@@ -2222,7 +2222,7 @@ void HttpFileServer::handle_api_mkdir(AsyncWebServerRequest *request) {
   // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
   std::string dir_uri;
 
-  auto *name_param = request->getParam("name", true);  // true = POST parameter
+  auto *name_param = request->getParam("name");  // POST parameter
   if (name_param) {
     dir_uri = name_param->value().c_str();
   } else {
@@ -2263,7 +2263,7 @@ void HttpFileServer::handle_api_delete(AsyncWebServerRequest *request) {
   // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
   std::string path_uri;
 
-  auto *path_param = request->getParam("path", true);  // true = POST parameter
+  auto *path_param = request->getParam("path");  // POST parameter
   if (path_param) {
     path_uri = path_param->value().c_str();
   } else {
@@ -2346,7 +2346,7 @@ void HttpFileServer::handle_api_mount(AsyncWebServerRequest *request) {
   // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
   std::string mount_point;
 
-  auto *mount_point_param = request->getParam("mount_point", true);  // true = POST parameter
+  auto *mount_point_param = request->getParam("mount_point");  // POST parameter
   if (mount_point_param) {
     mount_point = mount_point_param->value().c_str();
   } else {
@@ -2378,7 +2378,7 @@ void HttpFileServer::handle_api_unmount(AsyncWebServerRequest *request) {
   // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
   std::string mount_point;
 
-  auto *mount_point_param = request->getParam("mount_point", true);  // true = POST parameter
+  auto *mount_point_param = request->getParam("mount_point");  // POST parameter
   if (mount_point_param) {
     mount_point = mount_point_param->value().c_str();
   } else {
@@ -2410,7 +2410,7 @@ void HttpFileServer::handle_api_remount(AsyncWebServerRequest *request) {
   // Get parameters - try getParam() first (for URL-encoded), then body_buffer_ (for raw POST)
   std::string mount_point;
 
-  auto *mount_point_param = request->getParam("mount_point", true);  // true = POST parameter
+  auto *mount_point_param = request->getParam("mount_point");  // POST parameter
   if (mount_point_param) {
     mount_point = mount_point_param->value().c_str();
   } else {


### PR DESCRIPTION
ESP-IDF's AsyncWebServer::getParam() only accepts 1 parameter (name), not 2 parameters like Arduino's version. Removed the second 'true' parameter from all getParam() calls to fix compilation errors.

Fixes compilation errors:
- error: no matching function for call to 'getParam(const char[...], bool)'

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
