### PR TITLE
[http_file_server] Fix upload progress tracking with CORS headers

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -2537,7 +2537,9 @@ void HttpFileServer::handle_api_progress(AsyncWebServerRequest *request) {
   json += "}";
 
   ESP_LOGD(TAG, "Sending progress JSON response (%zu bytes): %s", json.length(), json.c_str());
-  request->send(200, "application/json", json.c_str());
+  AsyncWebServerResponse *response = request->beginResponse(200, "application/json", json.c_str());
+  response->addHeader("Access-Control-Allow-Credentials", "true");
+  request->send(response);
   ESP_LOGD(TAG, "Progress response sent");
 }
 


### PR DESCRIPTION
Add Access-Control-Allow-Credentials header to progress API response to fix XHR timeout issues when polling progress during upload operations.

The JavaScript progress polling uses xhr.withCredentials=true, which requires the server to explicitly send CORS headers. Without this header, browsers block the response causing status 0 errors and progress tracking failure.

This fix enables progress tracking for upload, copy, and move operations.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
