### PR TITLE
[http_file_server] Add CPU yielding to handleUpload for progress trac…

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -393,6 +393,9 @@ void HttpFileServer::handleUpload(AsyncWebServerRequest *request, const Platform
     this->progress_.start_time = millis();
     portEXIT_CRITICAL(&this->progress_mutex_);
 
+    // Reset yield tracking for upload
+    this->upload_bytes_since_yield_ = 0;
+
     this->upload_file_ = fopen(upload_path.c_str(), "wb");
     if (!this->upload_file_) {
       ESP_LOGE(TAG, "Failed to open file for async upload: %s", upload_path.c_str());
@@ -477,6 +480,15 @@ void HttpFileServer::handleUpload(AsyncWebServerRequest *request, const Platform
       this->progress_.transferred_bytes += written;
     }
     portEXIT_CRITICAL(&this->progress_mutex_);
+
+    // Yield CPU periodically to allow web server to handle other requests (like progress API)
+    // This follows the ESP-IDF multipart upload pattern (see web_server_idf/web_server_idf.cpp)
+    this->upload_bytes_since_yield_ += written;
+    static constexpr size_t YIELD_INTERVAL_BYTES = 16 * 1024;  // 16KB - same as ESP-IDF multipart handler
+    if (this->upload_bytes_since_yield_ >= YIELD_INTERVAL_BYTES) {
+      vTaskDelay(1);  // Brief yield to let other tasks run (including /api/progress requests)
+      this->upload_bytes_since_yield_ = 0;
+    }
   }
 
   // Finalize upload

--- a/esphome/components/http_file_server/http_file_server.h
+++ b/esphome/components/http_file_server/http_file_server.h
@@ -221,6 +221,7 @@ class HttpFileServer : public Component, public AsyncWebHandler {
   // Upload progress tracking
   size_t upload_total_size_{0};
   size_t upload_received_size_{0};
+  size_t upload_bytes_since_yield_{0};  // Track bytes to yield CPU periodically
 
   // Helper methods
   std::string uri_to_filepath(const std::string &uri);


### PR DESCRIPTION
…king

Follow ESP-IDF multipart upload pattern by yielding CPU every 16KB during upload processing. This allows the web server to handle other requests (especially /api/progress) while upload chunks are being written to disk.

Without yielding, handleUpload blocks the web server thread from responding to progress API requests, causing XHR timeouts in the browser and broken progress tracking.

Changes:
- Add upload_bytes_since_yield_ member to track bytes since last yield
- Reset yield counter when upload starts (index == 0)
- Yield via vTaskDelay(1) every 16KB (YIELD_INTERVAL_BYTES)
- Matches web_server_idf/web_server_idf.cpp:771-774 pattern

Fixes upload progress tracking for multipart/form-data uploads.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
