### PR TITLE
[http_file_server] Add Access-Control-Allow-Origin header for progres…

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -2550,7 +2550,23 @@ void HttpFileServer::handle_api_progress(AsyncWebServerRequest *request) {
 
   ESP_LOGD(TAG, "Sending progress JSON response (%zu bytes): %s", json.length(), json.c_str());
   AsyncWebServerResponse *response = request->beginResponse(200, "application/json", json);
+
+  // CORS headers for XHR with credentials - required even for same-origin requests
   response->addHeader("Access-Control-Allow-Credentials", "true");
+  // Get origin from Host header (same-origin case) or reflect Origin header
+  auto origin_header = request->get_header("Origin");
+  if (origin_header.has_value()) {
+    // Reflect the Origin header back for CORS
+    response->addHeader("Access-Control-Allow-Origin", origin_header.value().c_str());
+  } else {
+    // Construct origin from Host header for same-origin requests
+    auto host_header = request->get_header("Host");
+    if (host_header.has_value()) {
+      std::string origin = "http://" + host_header.value();
+      response->addHeader("Access-Control-Allow-Origin", origin.c_str());
+    }
+  }
+
   request->send(response);
   ESP_LOGD(TAG, "Progress response sent");
 }


### PR DESCRIPTION
…s API

When XHR uses withCredentials=true, browsers require BOTH CORS headers:
- Access-Control-Allow-Credentials: true
- Access-Control-Allow-Origin: <origin> (cannot be *)

This applies even to same-origin requests. Without the Allow-Origin header, browsers reject responses with XHR status 0, causing progress tracking to fail.

The fix reflects the Origin header if present, or constructs it from the Host header for same-origin requests.

This should resolve XHR timeout issues where ESP32 sends responses but browser never receives them.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
