### PR TITLE
[http_file_server] Fix chunked upload API URL construction

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1529,7 +1529,7 @@ std::string HttpFileServer::generate_html_footer() {
                     ' (bytes ' + start + '-' + end + ')');
 
         // Build API URL with query parameters
-        const apiUrl = window.location.pathname.replace(/\/+$/, '') + '/api/upload_chunk' +
+        const apiUrl = API_BASE + '/api/upload_chunk' +
                        '?filename=' + encodeURIComponent(file.name) +
                        '&chunkIndex=' + chunkIndex +
                        '&totalChunks=' + totalChunks +


### PR DESCRIPTION
Use API_BASE constant instead of window.location.pathname to build the API endpoint URL. This fixes the error where uploads from subdirectories would incorrectly call /files/subdir/api/upload_chunk instead of /files/api/upload_chunk, causing 'Upload target must be a directory' errors.

The path parameter correctly remains as window.location.pathname to indicate where the file should be uploaded.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
