### PR TITLE
[http_file_server] Fix chunked upload Content-Type to populate body b…

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1541,7 +1541,7 @@ std::string HttpFileServer::generate_html_footer() {
           body: chunk,
           credentials: 'include',
           headers: {
-            'Content-Type': 'application/octet-stream'
+            'Content-Type': 'application/x-www-form-urlencoded'
           }
         });
 


### PR DESCRIPTION
…uffer

Change Content-Type from 'application/octet-stream' to 'application/x-www-form-urlencoded' for chunk uploads.

The web_server_idf component does not populate body_buffer_ for octet-stream content type (it expects direct httpd_req_recv), causing all chunks to have empty body_buffer_ and zero bytes transferred.

Using form-urlencoded triggers the normal body handling path that populates body_buffer_ as expected by handle_api_upload_chunk().

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
