### PR TITLE
[http_file_server] Fix compilation error - use req->content_len directly

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -2740,7 +2740,7 @@ void HttpFileServer::handle_api_upload_chunk(AsyncWebServerRequest *request) {
   } else {
     // body_buffer_ is empty - read directly from httpd_req_t (octet-stream case)
     httpd_req_t *req = *request;  // Convert AsyncWebServerRequest to httpd_req_t
-    size_t content_len = httpd_req_get_content_len(req);
+    size_t content_len = req->content_len;
 
     if (content_len == 0) {
       ESP_LOGW(TAG, "Chunk %d has zero content length", chunk_index);


### PR DESCRIPTION
The function httpd_req_get_content_len() doesn't exist in ESP-IDF. Access content_len as a direct member of httpd_req_t structure instead.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
