### PR TITLE
[http_file_server] Reduce chunk size to 64KB for better throughput

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1513,7 +1513,7 @@ std::string HttpFileServer::generate_html_footer() {
     event.stopPropagation();
 
     // Chunked upload configuration
-    const CHUNK_SIZE = 500 * 1024; // 500KB chunks
+    const CHUNK_SIZE = 64 * 1024; // 64KB chunks for better responsiveness and throughput
     const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
 
     console.log('[FileServer] Starting chunked upload: ' + totalChunks + ' chunks of ' + CHUNK_SIZE + ' bytes');


### PR DESCRIPTION
Changed from 500KB to 64KB chunks. Smaller chunks provide:
- Better server responsiveness (less blocking per request)
- More efficient memory usage
- Improved overall throughput despite more requests
- Better progress granularity

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
