### PR TITLE
[http_file_server] Add timeout and early completion detection to chun…

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1536,36 +1536,60 @@ std::string HttpFileServer::generate_html_footer() {
                        '&path=' + encodeURIComponent(window.location.pathname) +
                        '&fileSize=' + file.size;
 
-        const response = await fetch(apiUrl, {
-          method: 'POST',
-          body: chunk,
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/octet-stream'
+        // Add timeout (60 seconds per chunk)
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 60000);
+
+        try {
+          const response = await fetch(apiUrl, {
+            method: 'POST',
+            body: chunk,
+            credentials: 'include',
+            headers: {
+              'Content-Type': 'application/octet-stream'
+            },
+            signal: controller.signal
+          });
+
+          clearTimeout(timeoutId);
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error('Chunk ' + (chunkIndex + 1) + ' failed: ' + errorText);
           }
-        });
 
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error('Chunk ' + (chunkIndex + 1) + ' failed: ' + errorText);
+          const result = await response.json();
+
+          // Check if upload was cancelled
+          if (result.cancelled) {
+            console.log('[FileServer] Upload cancelled by user');
+            hideProgressModal();
+            alert('Upload cancelled');
+            return false;
+          }
+
+          if (!result.success) {
+            throw new Error('Chunk ' + (chunkIndex + 1) + ' upload failed');
+          }
+
+          // Check if server thinks upload is complete
+          if (result.complete) {
+            if (chunkIndex < totalChunks - 1) {
+              // Server says complete but we have more chunks - something went wrong
+              throw new Error('Server completed upload early at chunk ' + (chunkIndex + 1) + '/' + totalChunks);
+            }
+            console.log('[FileServer] Upload completed by server at final chunk');
+          }
+
+          // Progress is automatically tracked by backend and polled by progress modal
+          console.log('[FileServer] Chunk ' + (chunkIndex + 1) + '/' + totalChunks + ' uploaded');
+        } catch (fetchError) {
+          clearTimeout(timeoutId);
+          if (fetchError.name === 'AbortError') {
+            throw new Error('Chunk ' + (chunkIndex + 1) + ' timed out after 60 seconds');
+          }
+          throw fetchError;
         }
-
-        const result = await response.json();
-
-        // Check if upload was cancelled
-        if (result.cancelled) {
-          console.log('[FileServer] Upload cancelled by user');
-          hideProgressModal();
-          alert('Upload cancelled');
-          return false;
-        }
-
-        if (!result.success) {
-          throw new Error('Chunk ' + (chunkIndex + 1) + ' upload failed');
-        }
-
-        // Progress is automatically tracked by backend and polled by progress modal
-        console.log('[FileServer] Chunk ' + (chunkIndex + 1) + '/' + totalChunks + ' uploaded');
       }
 
       console.log('[FileServer] All chunks uploaded successfully');

--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1546,7 +1546,8 @@ std::string HttpFileServer::generate_html_footer() {
             body: chunk,
             credentials: 'include',
             headers: {
-              'Content-Type': 'application/octet-stream'
+              'Content-Type': 'application/octet-stream',
+              'Connection': 'close'  // Force new connection per chunk to avoid keep-alive timeout
             },
             signal: controller.signal
           });


### PR DESCRIPTION
…ked upload

- Add 60-second timeout per chunk using AbortController
- Check server's 'complete' flag and error if set before last chunk
- Better error messages for timeout and premature completion
- Clear timeout on successful response

This helps diagnose and prevent the early completion issue where uploads finish before all chunks are transferred.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
