### PR TITLE
[http_file_server] Fix partial chunk reads by looping httpd_req_recv

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -2785,30 +2785,36 @@ void HttpFileServer::handle_api_upload_chunk(AsyncWebServerRequest *request) {
       // Allocate buffer for chunk data
       chunk_buffer = std::make_unique<uint8_t[]>(content_len);
 
-      // Read chunk data from HTTP request
-      int received = httpd_req_recv(req, reinterpret_cast<char *>(chunk_buffer.get()), content_len);
-      if (received <= 0) {
-        ESP_LOGE(TAG, "Failed to receive chunk %d data: httpd_req_recv returned %d", chunk_index, received);
-        fclose(this->upload_file_);
-        this->upload_file_ = nullptr;
+      // Read chunk data from HTTP request in a loop (httpd_req_recv may return partial reads)
+      size_t total_received = 0;
+      while (total_received < content_len) {
+        int ret = httpd_req_recv(req, reinterpret_cast<char *>(chunk_buffer.get()) + total_received,
+                                 content_len - total_received);
+        if (ret <= 0) {
+          ESP_LOGE(TAG, "Failed to receive chunk %d data: httpd_req_recv returned %d after %zu/%zu bytes", chunk_index,
+                   ret, total_received, content_len);
+          fclose(this->upload_file_);
+          this->upload_file_ = nullptr;
 
-        if (remove(upload_path.c_str()) == 0) {
-          ESP_LOGI(TAG, "Deleted partial upload file after receive failure: %s", upload_path.c_str());
-        } else {
-          ESP_LOGE(TAG, "Failed to delete partial upload file: %s (errno: %d)", upload_path.c_str(), errno);
+          if (remove(upload_path.c_str()) == 0) {
+            ESP_LOGI(TAG, "Deleted partial upload file after receive failure: %s", upload_path.c_str());
+          } else {
+            ESP_LOGE(TAG, "Failed to delete partial upload file: %s (errno: %d)", upload_path.c_str(), errno);
+          }
+
+          portENTER_CRITICAL(&this->progress_mutex_);
+          this->progress_.in_progress = false;
+          this->progress_.cancelled = false;
+          portEXIT_CRITICAL(&this->progress_mutex_);
+
+          request->send(500, "application/json", "{\"error\":\"Failed to receive chunk data\"}");
+          return;
         }
-
-        portENTER_CRITICAL(&this->progress_mutex_);
-        this->progress_.in_progress = false;
-        this->progress_.cancelled = false;
-        portEXIT_CRITICAL(&this->progress_mutex_);
-
-        request->send(500, "application/json", "{\"error\":\"Failed to receive chunk data\"}");
-        return;
+        total_received += ret;
       }
 
       data_ptr = chunk_buffer.get();
-      bytes_to_write = received;
+      bytes_to_write = total_received;
     }
   }
 


### PR DESCRIPTION
httpd_req_recv() can return partial reads - it doesn't guarantee reading the full requested amount in one call. This was causing chunks to be incomplete, resulting in files being truncated (e.g., 31MB written instead of 47MB expected).

Now loop calling httpd_req_recv() until all content_len bytes are received. This ensures complete chunks are written to disk.

Example of partial reads that are now fixed:
- Chunk expected 65536 bytes, only received 29344 (45%)
- Chunk expected 65536 bytes, only received 20704 (32%)

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
