### PR TITLE
[http_file_server] Remove Connection: close to enable HTTP keep-alive

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1549,8 +1549,7 @@ std::string HttpFileServer::generate_html_footer() {
             body: chunk,
             credentials: 'include',
             headers: {
-              'Content-Type': 'application/octet-stream',
-              'Connection': 'close'  // Force new connection per chunk to avoid keep-alive timeout
+              'Content-Type': 'application/octet-stream'
             },
             signal: controller.signal
           });


### PR DESCRIPTION
With the httpd_req_recv() loop properly handling partial reads, keep-alive connections should remain stable. Removing Connection: close eliminates the overhead of creating a new TCP connection for each 64KB chunk:

- No more 3-way handshake per chunk (SYN, SYN-ACK, ACK)
- No more 4-way connection teardown (FIN, ACK, FIN, ACK)
- Reuses existing connection for all chunks
- Should significantly improve throughput

Current performance: ~400 KB/s (5x improvement from initial 80 KB/s)
Target: Closer to 2 MB/s copy/move throughput

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
