### PR TITLE
[http_file_server] Use 256KB chunks with Connection: close for reliab…

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -1513,7 +1513,7 @@ std::string HttpFileServer::generate_html_footer() {
     event.stopPropagation();
 
     // Chunked upload configuration
-    const CHUNK_SIZE = 64 * 1024; // 64KB chunks for better responsiveness and throughput
+    const CHUNK_SIZE = 256 * 1024; // 256KB chunks for good balance of speed vs responsiveness
     const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
 
     console.log('[FileServer] Starting chunked upload: ' + totalChunks + ' chunks of ' + CHUNK_SIZE + ' bytes');
@@ -1549,7 +1549,8 @@ std::string HttpFileServer::generate_html_footer() {
             body: chunk,
             credentials: 'include',
             headers: {
-              'Content-Type': 'application/octet-stream'
+              'Content-Type': 'application/octet-stream',
+              'Connection': 'close'  // Force fresh connection to avoid socket exhaustion
             },
             signal: controller.signal
           });


### PR DESCRIPTION
…ility

Reverting to Connection: close with larger 256KB chunks to prevent:
1. Socket exhaustion (keep-alive + progress polls hitting 7 socket limit)
2. JSON response truncation from socket contention
3. Time-based upload failures

Trade-offs:
- 256KB vs 64KB = 4x fewer HTTP connections (215 vs 860 for 55MB)
- Connection: close overhead offset by fewer total connections
- Should reach closer to 2MB/s hardware capability
- Completes faster = avoids timeout issues

Previous attempts:
- 64KB + keep-alive: Socket exhaustion, 300 KB/s, stopped at 44MB
- 64KB + Connection: close: Worked but only 400 KB/s

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
