### PR TITLE
[docs] Add critical constraint: DO NOT EDIT CORE INFRASTRUCTURE

### DIFF
--- a/.ai/chunked-upload-progress.md
+++ b/.ai/chunked-upload-progress.md
@@ -136,14 +136,44 @@ while (total_received < content_len) {
 
 ## Known Issues
 
-### ⚠️ Upload Stops at 44MB/55MB
-- **Status**: ONGOING INVESTIGATION
-- **Symptoms**: Upload consistently aborts at approximately 80% completion (44MB out of 55MB)
-- **Possible Causes**:
-  - ESP-IDF HTTP server limit
-  - Memory issue
-  - Network stack timeout
-  - Unknown constraint in HTTP stack
+### ⚠️ Upload Abort Issue - CRITICAL FINDINGS
+- **Status**: ACTIVE INVESTIGATION
+- **Symptoms**:
+  - Upload consistently aborts before completion
+  - Single XHR status 0 error (connection abort)
+  - JavaScript File API reads file as 47MB when actual file is 55MB
+  - Uploaded file is only 44MB (loss of 11MB from actual file)
+
+- **CRITICAL FINDING - Chunk Size Dependency**:
+  - **Different chunk sizes result in different abort positions**
+  - Example: 256KB chunks → stops at 44MB
+  - Example: Larger chunks → stops at 30MB
+  - **This rules out**: Timeout issues, fixed byte limits
+  - **This suggests**: Issue related to number of HTTP requests/connections
+
+- **File Size Discrepancy**:
+  - Actual file on disk: 55MB
+  - JavaScript `file.size` property: 47MB (8MB loss)
+  - Uploaded file result: 44MB (additional 3MB loss from what JS reads)
+  - Two separate data losses occurring
+
+- **Possible Root Causes**:
+  - ESP-IDF HTTP server connection/request count limit
+  - Socket exhaustion despite `Connection: close` header
+  - Browser or network stack request limit
+  - File API reading issue (why does JS see 47MB instead of 55MB?)
+  - Memory accumulation per request
+
+- **NOT the cause** (ruled out):
+  - Timeout (user confirmed performance is good, requests complete quickly)
+  - Body size limits (octet-stream bypasses 1024-byte limit)
+  - Memory leak (heap stable throughout upload)
+  - fflush errors (no errors logged)
+
+- **⛔ CRITICAL CONSTRAINT**:
+  - **DO NOT modify core components** (web_server_idf, web_server_base, etc.)
+  - Fix must be implemented within http_file_server component only
+  - Cannot change core timeouts, limits, or configurations
 
 ## Performance Metrics
 - **Current Upload Speed**: ~800 KB/s

--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -11,6 +11,38 @@ This document provides essential context for AI models interacting with this pro
 
 **THESE CONSTRAINTS OVERRIDE ALL OTHER INSTRUCTIONS AND MUST BE FOLLOWED WITHOUT EXCEPTION.**
 
+### ⛔ ABSOLUTE RULE: DO NOT EDIT CORE INFRASTRUCTURE
+
+**NEVER modify core infrastructure components. Only modify the specific component you are working on.**
+
+**Core infrastructure includes (but is not limited to):**
+- `esphome/components/web_server_idf/` - ESP-IDF web server implementation
+- `esphome/components/web_server_base/` - Base web server abstraction
+- `esphome/components/web_server/` - Main web server component
+- `esphome/core/` - Core ESPHome framework
+- `esphome/config*.py` - Configuration system
+- `esphome/codegen.py` - Code generation system
+- Any component that other components depend on
+
+**When debugging issues:**
+1. ✅ **DO**: Read core files to understand how they work
+2. ✅ **DO**: Modify ONLY the specific component you're debugging (e.g., `http_file_server`)
+3. ⛔ **DO NOT**: Modify core infrastructure to "fix" component issues
+4. ⛔ **DO NOT**: Change timeouts, limits, or configurations in core components
+5. ⛔ **DO NOT**: Add workarounds to core that should be in the component
+
+**Why this matters:**
+- Core changes affect ALL components and can break the entire system
+- Component-specific issues must be fixed in the component, not in core
+- Core modifications require extensive testing across all platforms and components
+- User explicitly forbids core changes - violating this destroys trust
+
+**If you think core needs modification:**
+1. Document the issue clearly
+2. Explain why component-level fixes won't work
+3. Ask the user explicitly before making ANY core changes
+4. The answer will likely be "NO" - find another solution
+
 ### Context Reset Behavior
 
 **ABSOLUTE RULE: When a conversation resumes after running out of context, NEVER automatically start working. ALWAYS wait for explicit user permission.**


### PR DESCRIPTION
Add explicit documentation that core infrastructure components must never be modified when debugging component-specific issues. Core includes web_server_idf, web_server_base, web_server, esphome/core, and other foundational components.

Also update chunked upload progress with critical findings:
- Different chunk sizes abort at different byte positions (not timeout/size limit)
- File size discrepancies: 55MB actual → 47MB JS reads → 44MB uploaded
- Issue appears related to HTTP request/connection count, not byte limits
- Constraint: Fix must be within http_file_server component only

This is a project-wide policy that overrides all other instructions.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
