### PR TITLE
[http_file_server] Add single write permission check at start of oper…

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -2253,6 +2253,13 @@ void HttpFileServer::handle_api_copy(AsyncWebServerRequest *request) {
     return;
   }
 
+  // Check if destination directory is writable (only once at start of operation)
+  std::string dest_dir = Path::dirname(destination);
+  if (!this->is_directory_writable(dest_dir)) {
+    request->send(403, "application/json", "{\"error\":\"Destination directory is not writable\"}");
+    return;
+  }
+
   // Check if another operation is already in progress
   portENTER_CRITICAL(&this->progress_mutex_);
   bool already_in_progress = this->progress_.in_progress;
@@ -2311,6 +2318,13 @@ void HttpFileServer::handle_api_move(AsyncWebServerRequest *request) {
 
   if (S_ISDIR(src_stat.st_mode)) {
     request->send(400, "application/json", "{\"error\":\"Directory move not supported\"}");
+    return;
+  }
+
+  // Check if destination directory is writable (only once at start of operation)
+  std::string dest_dir = Path::dirname(destination);
+  if (!this->is_directory_writable(dest_dir)) {
+    request->send(403, "application/json", "{\"error\":\"Destination directory is not writable\"}");
     return;
   }
 
@@ -2769,6 +2783,12 @@ void HttpFileServer::handle_api_upload_chunk(AsyncWebServerRequest *request) {
     if (stat(dir_path.c_str(), &file_stat) != 0 || !S_ISDIR(file_stat.st_mode)) {
       ESP_LOGE(TAG, "Upload target is not a directory: %s", dir_path.c_str());
       request->send(400, "application/json", "{\"error\":\"Target is not a directory\"}");
+      return;
+    }
+
+    // Check if directory is writable (only once at start of upload)
+    if (!this->is_directory_writable(dir_path)) {
+      request->send(403, "application/json", "{\"error\":\"Upload directory is not writable\"}");
       return;
     }
 


### PR DESCRIPTION
…ations

Re-implement write permission checks, but only once at the start of each operation instead of repeatedly:
- Upload: Check only on first chunk (chunk_index == 0)
- Copy/Move: Check once before starting operation

This provides early error detection for permission issues without the performance overhead of creating/deleting test files during transfers. The dest-dir access will not change during transfer.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
