### PR TITLE
[http_file_server] Adjust yield frequency for 512KB chunks

### DIFF
--- a/esphome/components/http_file_server/http_file_server.cpp
+++ b/esphome/components/http_file_server/http_file_server.cpp
@@ -3324,8 +3324,8 @@ bool HttpFileServer::perform_file_copy(const std::string &src_path, const std::s
     }
 
     // Yield to other tasks periodically to allow web server to respond to progress polls
-    // Yield every 64 buffers (32MB with 512KB chunks)
-    if (buffer_count % 64 == 0) {
+    // Yield every 2 buffers (~1MB with 512KB chunks)
+    if (buffer_count % 2 == 0) {
       vTaskDelay(0);  // Yield to higher priority tasks only (no time delay)
 
       // Log progress for large files


### PR DESCRIPTION
With 512KB chunks, yield every 2 buffers (~1MB) to maintain responsive progress tracking while maximizing throughput.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
