### PR TITLE
[storage_host] Add automation trigger support to FileManager

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.h
+++ b/esphome/components/picture_viewer/picture_viewer.h
@@ -63,7 +63,7 @@ enum class SlideshowMode {
 class PictureViewer : public Component {
  public:
   PictureViewer() = default;
-  ~PictureViewer() override;
+  ~PictureViewer();
 
   // Component lifecycle
   void setup() override;

--- a/esphome/components/storage_host/file_manager.cpp
+++ b/esphome/components/storage_host/file_manager.cpp
@@ -233,6 +233,9 @@ void FileManager::perform_scan_() {
           ESP_LOGD(TAG, "File added: %s", info.filename.c_str());
           change_info.added.push_back(info);
           this->file_added_callbacks_.call(info);
+          for (auto *trigger : this->file_added_triggers_) {
+            trigger->trigger(info);
+          }
         }
       } else {
         // Check if modified
@@ -240,6 +243,9 @@ void FileManager::perform_scan_() {
           ESP_LOGD(TAG, "File modified: %s", info.filename.c_str());
           change_info.modified.push_back(info);
           this->file_modified_callbacks_.call(info);
+          for (auto *trigger : this->file_modified_triggers_) {
+            trigger->trigger(info);
+          }
         }
       }
     }
@@ -252,6 +258,9 @@ void FileManager::perform_scan_() {
           ESP_LOGD(TAG, "File deleted: %s", info.filename.c_str());
           change_info.deleted.push_back(info);
           this->file_deleted_callbacks_.call(info);
+          for (auto *trigger : this->file_deleted_triggers_) {
+            trigger->trigger(info);
+          }
         }
       }
     }
@@ -266,6 +275,9 @@ void FileManager::perform_scan_() {
       ESP_LOGD(TAG, "Directory changed: %s (added: %zu, modified: %zu, deleted: %zu)", this->watch_directory_.c_str(),
                change_info.added.size(), change_info.modified.size(), change_info.deleted.size());
       this->directory_changed_callbacks_.call(change_info);
+      for (auto *trigger : this->directory_changed_triggers_) {
+        trigger->trigger(change_info);
+      }
     }
 
     this->initial_scan_done_ = true;

--- a/esphome/components/storage_host/file_manager.h
+++ b/esphome/components/storage_host/file_manager.h
@@ -107,7 +107,12 @@ class FileManager : public Component {
   void set_min_size(uint64_t size) { this->min_size_ = size; }
   void set_max_size(uint64_t size) { this->max_size_ = size; }
 
-  // Trigger registration
+  // Trigger registration (for automation)
+  void add_on_file_added_callback(FileAddedTrigger *trigger) { this->file_added_triggers_.push_back(trigger); }
+  void add_on_file_modified_callback(FileModifiedTrigger *trigger) { this->file_modified_triggers_.push_back(trigger); }
+  void add_on_file_deleted_callback(FileDeletedTrigger *trigger) { this->file_deleted_triggers_.push_back(trigger); }
+
+  // Callback registration (for lambdas)
   void add_on_file_added_callback(std::function<void(FileInfo)> &&callback) {
     this->file_added_callbacks_.add(std::move(callback));
   }
@@ -116,6 +121,9 @@ class FileManager : public Component {
   }
   void add_on_file_deleted_callback(std::function<void(FileInfo)> &&callback) {
     this->file_deleted_callbacks_.add(std::move(callback));
+  }
+  void add_on_directory_changed_callback(DirectoryChangedTrigger *trigger) {
+    this->directory_changed_triggers_.push_back(trigger);
   }
   void add_on_directory_changed_callback(std::function<void(DirectoryChangeInfo)> &&callback) {
     this->directory_changed_callbacks_.add(std::move(callback));
@@ -161,6 +169,12 @@ class FileManager : public Component {
   std::map<std::string, FileInfo> directory_state_;  // Current known files (key: full path)
   uint32_t last_scan_time_{0};
   bool initial_scan_done_{false};
+
+  // Automation triggers
+  std::vector<FileAddedTrigger *> file_added_triggers_;
+  std::vector<FileModifiedTrigger *> file_modified_triggers_;
+  std::vector<FileDeletedTrigger *> file_deleted_triggers_;
+  std::vector<DirectoryChangedTrigger *> directory_changed_triggers_;
 
   // Callbacks
   CallbackManager<void(FileInfo)> file_added_callbacks_;


### PR DESCRIPTION
- Add overloaded methods to accept both Trigger* and std::function callbacks
- Add trigger vectors to store automation triggers
- Fire automation triggers alongside callbacks for file events:
  - file_added
  - file_modified
  - file_deleted
  - directory_changed
- Fix PictureViewer destructor not being marked override (Component has no virtual destructor)

This enables ESPHome automation system integration with FileManager events.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
