### PR TITLE
[picture_viewer] Fix scan_directory_() to use actual FileManager API

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -267,8 +267,8 @@ void PictureViewer::scan_directory_() {
     return;
   }
 
-  auto files = this->file_manager_->get_files();
-  for (const auto &file : files) {
+  const auto &directory_state = this->file_manager_->get_directory_state();
+  for (const auto &[path, file] : directory_state) {
     // Filter JPEG files
     std::string lower_filename = file.filename;
     std::transform(lower_filename.begin(), lower_filename.end(), lower_filename.begin(), ::tolower);


### PR DESCRIPTION
Use get_directory_state() instead of non-existent get_files() method. FileManager stores directory state as a map<string, FileInfo>, not a vector.

This fixes compilation error:
  error: 'class esphome::storage_host::FileManager' has no member named 'get_files'

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
