### PR TITLE
[picture_viewer] Implement LVGL canvas drawing with configurable fit …

### DIFF
--- a/esphome/components/picture_viewer/__init__.py
+++ b/esphome/components/picture_viewer/__init__.py
@@ -23,6 +23,13 @@ PictureViewer = picture_viewer_ns.class_("PictureViewer", cg.Component)
 
 # Enums
 SlideshowMode = picture_viewer_ns.enum("SlideshowMode")
+ImageFitMode = picture_viewer_ns.enum("ImageFitMode")
+IMAGE_FIT_MODES = {
+    "SCALE_TO_FIT": ImageFitMode.SCALE_TO_FIT,
+    "SCALE_TO_FILL": ImageFitMode.SCALE_TO_FILL,
+    "STRETCH": ImageFitMode.STRETCH,
+    "CENTER": ImageFitMode.CENTER,
+}
 
 # Configuration keys
 CONF_FILE_MANAGER_ID = "file_manager_id"
@@ -33,6 +40,7 @@ CONF_SLIDESHOW_INTERVAL = "slideshow_interval"
 CONF_ENABLE_THUMBNAILS = "enable_thumbnails"
 CONF_THUMBNAIL_WIDTH = "thumbnail_width"
 CONF_THUMBNAIL_HEIGHT = "thumbnail_height"
+CONF_FIT_MODE = "fit_mode"
 
 # Component configuration
 CONFIG_SCHEMA = cv.Schema(
@@ -48,6 +56,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_ENABLE_THUMBNAILS, default=True): cv.boolean,
         cv.Optional(CONF_THUMBNAIL_WIDTH, default=120): cv.int_range(min=32, max=320),
         cv.Optional(CONF_THUMBNAIL_HEIGHT, default=90): cv.int_range(min=32, max=240),
+        cv.Optional(CONF_FIT_MODE, default="SCALE_TO_FIT"): cv.enum(
+            IMAGE_FIT_MODES, upper=True
+        ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -62,9 +73,19 @@ async def to_code(config):
         fm = await cg.get_variable(config[CONF_FILE_MANAGER_ID])
         cg.add(var.set_file_manager(fm))
 
-    # Link LVGL canvas if provided (pass as string - LVGL uses its own ID system)
+    # Link LVGL canvas if provided
     if CONF_CANVAS_ID in config:
-        cg.add(var.set_canvas_id(config[CONF_CANVAS_ID]))
+        canvas_id = config[CONF_CANVAS_ID]
+        cg.add(var.set_canvas_id(canvas_id))
+        # Generate lambda to pass the canvas object pointer at runtime
+        # The canvas_id becomes a C++ global variable of type lv_obj_t*
+        cg.add_lambda(
+            f"""
+            if ({canvas_id} != nullptr) {{
+                id({config[CONF_ID]})->set_canvas({canvas_id});
+            }}
+            """
+        )
 
     # Link display if provided
     if CONF_DISPLAY_ID in config:
@@ -77,6 +98,7 @@ async def to_code(config):
     cg.add(var.set_enable_thumbnails(config[CONF_ENABLE_THUMBNAILS]))
     cg.add(var.set_thumbnail_width(config[CONF_THUMBNAIL_WIDTH]))
     cg.add(var.set_thumbnail_height(config[CONF_THUMBNAIL_HEIGHT]))
+    cg.add(var.set_fit_mode(config[CONF_FIT_MODE]))
 
     # Add defines based on platform
     from esphome.components.esp32 import get_esp32_variant, add_idf_component

--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -457,14 +457,123 @@ void PictureViewer::resize_image_(const std::vector<uint8_t> &src_data, int src_
 
 void PictureViewer::update_canvas_() {
 #ifdef USE_LVGL
-  if (this->canvas_id_.empty()) {
-    ESP_LOGW(TAG, "Canvas ID not set");
+  if (this->canvas_ == nullptr) {
+    ESP_LOGW(TAG, "Canvas not set");
     return;
   }
 
-  // TODO: Update LVGL canvas with current_image_data_
-  // This requires LVGL integration to find the canvas widget and update it
-  ESP_LOGD(TAG, "Updating canvas: %s", this->canvas_id_.c_str());
+  if (this->current_image_data_ == nullptr) {
+    ESP_LOGW(TAG, "No image data to display");
+    return;
+  }
+
+  // Get canvas buffer
+  lv_canvas_ext_t *ext = (lv_canvas_ext_t *) lv_obj_get_ext_attr(this->canvas_);
+  if (ext == nullptr || ext->dsc.data == nullptr) {
+    ESP_LOGE(TAG, "Canvas buffer not initialized");
+    return;
+  }
+
+  // Get canvas dimensions
+  lv_coord_t canvas_width = lv_obj_get_width(this->canvas_);
+  lv_coord_t canvas_height = lv_obj_get_height(this->canvas_);
+
+  ESP_LOGD(TAG, "Canvas: %dx%d, Image: %dx%d, Fit mode: %d", canvas_width, canvas_height, this->current_image_width_,
+           this->current_image_height_, static_cast<int>(this->fit_mode_));
+
+  // Calculate drawing dimensions and position based on fit mode
+  int draw_x = 0, draw_y = 0;
+  int draw_width = this->current_image_width_;
+  int draw_height = this->current_image_height_;
+
+  switch (this->fit_mode_) {
+    case ImageFitMode::SCALE_TO_FIT: {
+      // Scale to fit, maintain aspect ratio
+      float scale_x = static_cast<float>(canvas_width) / this->current_image_width_;
+      float scale_y = static_cast<float>(canvas_height) / this->current_image_height_;
+      float scale = std::min(scale_x, scale_y);
+
+      draw_width = static_cast<int>(this->current_image_width_ * scale);
+      draw_height = static_cast<int>(this->current_image_height_ * scale);
+
+      // Center in canvas
+      draw_x = (canvas_width - draw_width) / 2;
+      draw_y = (canvas_height - draw_height) / 2;
+
+      // Clear canvas with black background
+      lv_canvas_fill_bg(this->canvas_, lv_color_black(), LV_OPA_COVER);
+      break;
+    }
+
+    case ImageFitMode::SCALE_TO_FILL: {
+      // Scale to fill, maintain aspect ratio, may crop
+      float scale_x = static_cast<float>(canvas_width) / this->current_image_width_;
+      float scale_y = static_cast<float>(canvas_height) / this->current_image_height_;
+      float scale = std::max(scale_x, scale_y);
+
+      draw_width = static_cast<int>(this->current_image_width_ * scale);
+      draw_height = static_cast<int>(this->current_image_height_ * scale);
+
+      // Center in canvas (may be cropped)
+      draw_x = (canvas_width - draw_width) / 2;
+      draw_y = (canvas_height - draw_height) / 2;
+      break;
+    }
+
+    case ImageFitMode::STRETCH: {
+      // Stretch to fill canvas, ignore aspect ratio
+      draw_width = canvas_width;
+      draw_height = canvas_height;
+      draw_x = 0;
+      draw_y = 0;
+      break;
+    }
+
+    case ImageFitMode::CENTER: {
+      // Center without scaling
+      draw_x = (canvas_width - this->current_image_width_) / 2;
+      draw_y = (canvas_height - this->current_image_height_) / 2;
+
+      // Clear canvas with black background
+      lv_canvas_fill_bg(this->canvas_, lv_color_black(), LV_OPA_COVER);
+      break;
+    }
+  }
+
+  // Need to scale/copy the image data to canvas if dimensions don't match
+  if (draw_width == this->current_image_width_ && draw_height == this->current_image_height_) {
+    // Direct copy - no scaling needed
+    lv_img_dsc_t img_dsc;
+    img_dsc.header.always_zero = 0;
+    img_dsc.header.w = this->current_image_width_;
+    img_dsc.header.h = this->current_image_height_;
+    img_dsc.header.cf = LV_IMG_CF_TRUE_COLOR;  // RGB565
+    img_dsc.data_size = this->current_image_size_;
+    img_dsc.data = this->current_image_data_;
+
+    lv_canvas_draw_img(this->canvas_, draw_x, draw_y, &img_dsc, nullptr);
+  } else {
+    // Need to scale the image
+    std::vector<uint8_t> scaled_data;
+    this->resize_image_(std::vector<uint8_t>(this->current_image_data_,
+                                              this->current_image_data_ + this->current_image_size_),
+                        this->current_image_width_, this->current_image_height_, scaled_data, draw_width, draw_height);
+
+    lv_img_dsc_t img_dsc;
+    img_dsc.header.always_zero = 0;
+    img_dsc.header.w = draw_width;
+    img_dsc.header.h = draw_height;
+    img_dsc.header.cf = LV_IMG_CF_TRUE_COLOR;  // RGB565
+    img_dsc.data_size = scaled_data.size();
+    img_dsc.data = scaled_data.data();
+
+    lv_canvas_draw_img(this->canvas_, draw_x, draw_y, &img_dsc, nullptr);
+  }
+
+  // Invalidate canvas to trigger redraw
+  lv_obj_invalidate(this->canvas_);
+
+  ESP_LOGD(TAG, "Canvas updated successfully");
 #endif
 }
 
@@ -497,11 +606,17 @@ bool PictureViewer::generate_thumbnail_(ImageEntry &entry) {
 
 void PictureViewer::update_canvas_dimensions_() {
 #ifdef USE_LVGL
-  // TODO: Get canvas dimensions from LVGL widget
-  // For now, use defaults
-  if (this->canvas_width_ == 0 || this->canvas_height_ == 0) {
-    this->canvas_width_ = 800;
-    this->canvas_height_ = 480;
+  if (this->canvas_ != nullptr) {
+    this->canvas_width_ = lv_obj_get_width(this->canvas_);
+    this->canvas_height_ = lv_obj_get_height(this->canvas_);
+    ESP_LOGD(TAG, "Canvas dimensions: %dx%d", this->canvas_width_, this->canvas_height_);
+  } else {
+    // Fallback to defaults if canvas not set
+    if (this->canvas_width_ == 0 || this->canvas_height_ == 0) {
+      this->canvas_width_ = 800;
+      this->canvas_height_ = 480;
+      ESP_LOGW(TAG, "Canvas not set, using default dimensions: %dx%d", this->canvas_width_, this->canvas_height_);
+    }
   }
 #endif
 }

--- a/esphome/components/picture_viewer/picture_viewer.h
+++ b/esphome/components/picture_viewer/picture_viewer.h
@@ -56,6 +56,14 @@ enum class SlideshowMode {
   PAUSED,
 };
 
+// Image fit mode for canvas display
+enum class ImageFitMode {
+  SCALE_TO_FIT,   // Scale to fit canvas, maintain aspect ratio (may have black bars)
+  SCALE_TO_FILL,  // Scale to fill canvas, maintain aspect ratio (may crop)
+  STRETCH,        // Stretch to fill canvas, ignore aspect ratio
+  CENTER,         // Center image, no scaling
+};
+
 // =====================================================
 // PictureViewer Component
 // =====================================================
@@ -81,6 +89,7 @@ class PictureViewer : public Component {
 
 #ifdef USE_LVGL
   void set_canvas_id(const std::string &canvas_id) { this->canvas_id_ = canvas_id; }
+  void set_canvas(lv_obj_t *canvas) { this->canvas_ = canvas; }
   void set_display(display::Display *display) { this->display_ = display; }
 #endif
 
@@ -89,6 +98,7 @@ class PictureViewer : public Component {
   void set_thumbnail_width(int width) { this->thumbnail_width_ = width; }
   void set_thumbnail_height(int height) { this->thumbnail_height_ = height; }
   void set_enable_thumbnails(bool enable) { this->enable_thumbnails_ = enable; }
+  void set_fit_mode(ImageFitMode mode) { this->fit_mode_ = mode; }
 
   // =====================================================
   // Picture Control API
@@ -152,7 +162,8 @@ class PictureViewer : public Component {
 #endif
 
 #ifdef USE_LVGL
-  std::string canvas_id_;  // LVGL canvas widget ID
+  std::string canvas_id_;  // LVGL canvas widget ID (for debugging)
+  lv_obj_t *canvas_{nullptr};  // LVGL canvas object pointer
   display::Display *display_{nullptr};
 #endif
 
@@ -161,6 +172,7 @@ class PictureViewer : public Component {
   int thumbnail_width_{120};
   int thumbnail_height_{90};
   bool enable_thumbnails_{true};
+  ImageFitMode fit_mode_{ImageFitMode::SCALE_TO_FIT};  // Default: scale to fit
 
   // State
   std::vector<ImageEntry> images_;


### PR DESCRIPTION
…modes

Major Features:
- Add ImageFitMode enum with 4 modes:
  * SCALE_TO_FIT: Scale to fit canvas, maintain aspect ratio (black bars)
  * SCALE_TO_FILL: Scale to fill canvas, maintain aspect ratio (may crop)
  * STRETCH: Stretch to fill canvas, ignore aspect ratio
  * CENTER: Center image, no scaling
- Add fit_mode configuration option (default: SCALE_TO_FIT)

LVGL Integration:
- Add set_canvas(lv_obj_t*) to accept canvas object pointer
- Generate lambda in Python to pass canvas pointer at runtime
- Implement full update_canvas_() with:
  * Fit mode calculation and positioning
  * Image scaling/resizing when needed
  * Direct drawing for matching dimensions
  * Canvas invalidation for redraw
- Implement update_canvas_dimensions_() to get actual canvas size

Canvas Drawing:
- Use lv_canvas_draw_img() for rendering RGB565 data
- Support both direct copy and scaled rendering
- Clear canvas background for modes with black bars
- Proper aspect ratio calculation for all fit modes

This completes the picture viewer implementation - images should now actually display on the LVGL canvas!

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
