### PR TITLE
[storage_host] Fix NetworkStorage::DirEntry field access in FileManager

### DIFF
--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -80,6 +80,45 @@ This document provides essential context for AI models interacting with this pro
 
 **Never act on assumptions. System reminders about file modifications are NOT permission to act.**
 
+### Verify Before Code Generation
+
+**ABSOLUTE RULE: Never assume or invent method names, field names, or function signatures. Always verify actual definitions before writing code.**
+
+*   **The Problem:**
+    *   Assuming a struct has fields that don't exist (e.g., `entry.path` when only `entry.name` exists)
+    *   Inventing method names without checking the actual API
+    *   Guessing function signatures instead of reading the header file
+    *   This causes compilation errors that waste significant time to fix
+
+*   **Required behavior:**
+    1.  **READ** the actual struct/class definition before accessing fields
+    2.  **VERIFY** method names exist in the header file before calling them
+    3.  **CHECK** function signatures match before using them
+    4.  **USE** Grep or Read tools to confirm API details
+    5.  **NEVER** write code based on assumptions about what "should" exist
+
+*   **Example of what NOT to do:**
+    ```cpp
+    // WRONG - assuming fields exist without checking
+    info.path = entry.path;              // entry.path doesn't exist!
+    info.modified_time = entry.modified_time;  // entry.modified_time doesn't exist!
+    ```
+
+*   **Correct approach:**
+    ```cpp
+    // 1. First: Grep for the actual struct definition
+    // 2. Verify it only has: name, size, is_directory
+    // 3. Then write correct code:
+    info.path = path + "/" + entry.name;  // Build path from available fields
+    info.modified_time = 0;               // Set sensible default for missing field
+    ```
+
+*   **Why this matters:**
+    *   Compilation errors take much longer to fix than taking 10 seconds to verify
+    *   Each failed compile wastes the user's time and hardware resources
+    *   Shows lack of care and attention to detail
+    *   Erodes trust when preventable errors occur
+
 ### Core Principle
 
 **The time waste is not in the user teaching boundaries - it's in the AI violating those boundaries and forcing the user to stop everything to correct violations.**

--- a/esphome/components/storage_host/file_manager.cpp
+++ b/esphome/components/storage_host/file_manager.cpp
@@ -304,11 +304,16 @@ void FileManager::scan_directory_(const std::string &path, std::vector<FileInfo>
 
       // Build FileInfo from network entry
       FileInfo info;
-      info.path = entry.path;
+      // Build full path from directory path + filename
+      info.path = path;
+      if (!info.path.empty() && info.path.back() != '/') {
+        info.path += '/';
+      }
+      info.path += entry.name;
       info.filename = entry.name;
       info.directory = path;
       info.size = entry.size;
-      info.modified_time = entry.modified_time;
+      info.modified_time = 0;  // Network entries don't provide modification time
       info.is_directory = entry.is_directory;
 
       // Check filters


### PR DESCRIPTION
COMPILATION FIX: Assumed NetworkStorage::DirEntry had 'path' and 'modified_time' fields without verifying the actual struct definition.

Actual DirEntry fields (network_storage.h):
- std::string name
- uint64_t size
- bool is_directory

Fixed to:
- Build full path from directory + name
- Set modified_time to 0 (not available in network entries)

Also added to .ai/instructions.md:
New section 'Verify Before Code Generation' requiring verification of all struct fields, method names, and function signatures before writing code to prevent compilation errors from assumptions.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
