### PR TITLE
[storage_host] Fix FileManager to support virtual root and proper mou…

### DIFF
--- a/esphome/components/storage_host/file_manager.cpp
+++ b/esphome/components/storage_host/file_manager.cpp
@@ -203,13 +203,7 @@ void FileManager::perform_scan_() {
 
   // Directory watch mode
   if (!this->watch_directory_.empty()) {
-    // Check if directory is available
-    if (!this->is_path_available(this->watch_directory_)) {
-      ESP_LOGD(TAG, "Directory not available: %s", this->watch_directory_.c_str());
-      return;
-    }
-
-    // Scan directory
+    // Scan directory (scan_directory_() will handle mount point validation and graceful failure)
     std::vector<FileInfo> current_files;
     this->scan_directory_(this->watch_directory_, current_files);
 
@@ -287,8 +281,47 @@ void FileManager::perform_scan_() {
 }
 
 void FileManager::scan_directory_(const std::string &path, std::vector<FileInfo> &files) {
+  if (this->storage_host_ == nullptr) {
+    ESP_LOGD(TAG, "StorageHost not available");
+    return;
+  }
+
+  // Check if this is virtual root - list mount points
+  bool is_virtual_root = (path.empty() || path == "/");
+  if (is_virtual_root) {
+    ESP_LOGD(TAG, "Listing mount points from virtual root");
+    const auto &mounts = this->storage_host_->get_mounts();
+    for (const auto &mount : mounts) {
+      FileInfo info;
+      info.path = mount.path;
+      info.filename = mount.path.substr(1);  // Remove leading slash
+      if (info.filename.empty()) {
+        info.filename = "root";
+      }
+      info.directory = "/";
+      info.size = 0;
+      info.modified_time = 0;
+      info.is_directory = true;
+
+      // Check if pattern matches (mount points should match "*" pattern)
+      if (this->matches_pattern_(info.filename)) {
+        files.push_back(info);
+      }
+    }
+    return;
+  }
+
+  // Parse path to extract mount point
+  std::string mount_point = this->storage_host_->find_mount_for_path(path);
+  if (mount_point.empty()) {
+    ESP_LOGD(TAG, "No mount point found for path: %s", path.c_str());
+    return;
+  }
+
+  ESP_LOGV(TAG, "Found mount point '%s' for path '%s'", mount_point.c_str(), path.c_str());
+
   // Check if this is a network path - use StorageHost methods for proper routing
-  if (this->storage_host_ && this->storage_host_->is_network_path(path)) {
+  if (this->storage_host_->is_network_path(path)) {
     // Use network storage backend
     std::vector<NetworkStorage::DirEntry> entries;
     if (!this->storage_host_->network_list_directory(path, entries)) {
@@ -327,7 +360,7 @@ void FileManager::scan_directory_(const std::string &path, std::vector<FileInfo>
   // Local filesystem access - use opendir()
   DIR *dir = opendir(path.c_str());
   if (dir == nullptr) {
-    ESP_LOGD(TAG, "Failed to open directory: %s (errno: %d)", path.c_str(), errno);
+    ESP_LOGD(TAG, "Failed to open directory: %s (errno: %d, mount: %s)", path.c_str(), errno, mount_point.c_str());
     return;
   }
 


### PR DESCRIPTION
…nt point routing

Critical fixes to enable file_manager to work like http_file_server:

1. **Add Virtual Root Support**
   - Detect if path is "/" or empty
   - List mount points from storage_host as virtual directories
   - Matches http_file_server pattern for consistency

2. **Add Mount Point Validation**
   - Parse path to extract mount point before scanning
   - Log mount point found for better debugging
   - Return empty gracefully if no mount point found

3. **Remove Early Abort in perform_scan_()**
   - Previously aborted entire scan if path not "available"
   - Now lets scan_directory_() handle failures gracefully
   - Allows retries on subsequent scan intervals

4. **Enhanced Logging**
   - Added mount point to opendir() failure log
   - Added verbose logging for mount point resolution
   - Helps diagnose SD card mount timing issues

**Why These Changes:**
file_manager must handle the virtual filesystem like http_file_server does:
- Microcontroller has no real root filesystem
- Must enumerate VFS mount points (SD, USB, network)
- Must route to correct VFS based on path prefix
- Must gracefully handle mount not yet available

**Fixes:** "no files" issue where file_manager couldn't scan directories because it didn't understand virtual root and mount point routing.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
