### PR TITLE
[picture_viewer] Fix ESP32-P4 hardware JPEG decoder to use aligned bu…

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -410,33 +410,73 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
     return false;
   }
 
+  // Get image info
   jpeg_decode_picture_info_t pic_info = {};
-  esp_err_t ret =
-      jpeg_decoder_get_info(jpeg_data.data(), static_cast<uint32_t>(jpeg_data.size()), &pic_info);
+  esp_err_t ret = jpeg_decoder_get_info(jpeg_data.data(), static_cast<uint32_t>(jpeg_data.size()), &pic_info);
   if (ret != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to get JPEG info: %d", ret);
+    ESP_LOGE(TAG, "Failed to get JPEG info: %s", esp_err_to_name(ret));
     return false;
   }
+
+  ESP_LOGD(TAG, "JPEG dimensions: %dx%d", pic_info.width, pic_info.height);
 
   width = pic_info.width;
   height = pic_info.height;
 
-  // Allocate output buffer for RGB565
-  size_t output_size = width * height * 2;  // RGB565 = 2 bytes per pixel
-  rgb565_data.resize(output_size);
+  // Calculate buffer sizes
+  uint32_t input_size = jpeg_data.size();
+  uint32_t output_size = width * height * 2;  // RGB565 = 2 bytes per pixel
 
+  // Allocate 16-byte aligned buffers (hardware requirement)
+  uint8_t *aligned_input = (uint8_t *) heap_caps_aligned_alloc(16, input_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (!aligned_input) {
+    ESP_LOGE(TAG, "Failed to allocate aligned input buffer (%u bytes)", input_size);
+    return false;
+  }
+
+  uint8_t *aligned_output = (uint8_t *) heap_caps_aligned_alloc(16, output_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (!aligned_output) {
+    ESP_LOGE(TAG, "Failed to allocate aligned output buffer (%u bytes)", output_size);
+    free(aligned_input);
+    return false;
+  }
+
+  // Copy input data to aligned buffer
+  memcpy(aligned_input, jpeg_data.data(), input_size);
+
+  // Configure decoder
   jpeg_decode_cfg_t decode_cfg = {
       .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
       .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_RGB,
   };
 
-  ret = jpeg_decoder_process(this->hw_decoder_, &decode_cfg, jpeg_data.data(),
-                             static_cast<uint32_t>(jpeg_data.size()), rgb565_data.data(),
-                             static_cast<uint32_t>(output_size), nullptr);
+  // Decode
+  ret = jpeg_decoder_process(this->hw_decoder_, &decode_cfg, aligned_input, input_size, aligned_output, output_size,
+                             &output_size);
+
   if (ret != ESP_OK) {
-    ESP_LOGE(TAG, "Hardware JPEG decode failed: %d", ret);
+    ESP_LOGE(TAG, "Hardware JPEG decode failed: %s", esp_err_to_name(ret));
+    free(aligned_input);
+    free(aligned_output);
     return false;
   }
+
+  ESP_LOGD(TAG, "Hardware decode completed, output size: %u bytes", output_size);
+
+  // Byte-swap RGB565 for correct endianness
+  uint16_t *pixels = (uint16_t *) aligned_output;
+  size_t pixel_count = output_size / 2;
+  for (size_t i = 0; i < pixel_count; i++) {
+    pixels[i] = (pixels[i] << 8) | (pixels[i] >> 8);
+  }
+
+  // Copy to output vector
+  rgb565_data.resize(output_size);
+  memcpy(rgb565_data.data(), aligned_output, output_size);
+
+  // Free aligned buffers
+  free(aligned_input);
+  free(aligned_output);
 
   ESP_LOGD(TAG, "Decoded JPEG using hardware decoder: %dx%d", width, height);
   return true;


### PR DESCRIPTION
…ffers

Fix hardware JPEG decoder by using 16-byte aligned buffers and byte-swapping, based on the working storage_images implementation.

Key fixes:
- Use heap_caps_aligned_alloc() for 16-byte aligned input/output buffers (hardware decoder requirement)
- Copy JPEG data to aligned input buffer before decode
- Byte-swap RGB565 pixels after decode for correct endianness
- Free aligned buffers after copying to output vector

This fixes error 258 (ESP_ERR_INVALID_ARG) which was caused by passing unaligned std::vector buffers to the hardware decoder.

The ESP32-P4 hardware JPEG decoder requires:
1. Input and output buffers must be 16-byte aligned
2. RGB565 output needs byte-swapping (pixels[i] << 8 | pixels[i] >> 8)

Reference: storage_host/storage_images component (commit 06190c6) which successfully decoded these same JPEGs using the hardware decoder.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
