### PR TITLE
[picture_viewer] Fix hardware JPEG decoder engine config

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -52,11 +52,12 @@ void PictureViewer::setup() {
 #ifdef USE_HARDWARE_JPEG_DECODER
   // Initialize hardware JPEG decoder for ESP32-P4
   jpeg_decode_engine_cfg_t decode_eng_cfg = {
-      .timeout_ms = 40,
+      .intr_priority = 0,
+      .timeout_ms = 200,
   };
   esp_err_t ret = jpeg_new_decoder_engine(&decode_eng_cfg, &this->hw_decoder_);
   if (ret != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to create hardware JPEG decoder: %d", ret);
+    ESP_LOGE(TAG, "Failed to create hardware JPEG decoder: %s", esp_err_to_name(ret));
     this->mark_failed();
     return;
   }


### PR DESCRIPTION
Fix decoder engine initialization to match working storage_images code:
- Add missing .intr_priority = 0 field (was causing ESP_ERR_INVALID_ARG)
- Increase timeout from 40ms to 200ms (needed for 1280x800 images)
- Use esp_err_to_name() for better error messages

The missing intr_priority field was causing the decoder to be initialized incorrectly, resulting in ESP_ERR_INVALID_ARG during decode.

Reference: storage_host/storage_images (commit 06190c6)

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
