### PR TITLE
[picture_viewer] Add comprehensive debug logging for hardware JPEG de…

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -451,12 +451,24 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
       .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_RGB,
   };
 
+  // Debug: Log all parameters before decode
+  ESP_LOGI(TAG, "[DECODE DEBUG] Decoder handle: %p", this->hw_decoder_);
+  ESP_LOGI(TAG, "[DECODE DEBUG] Input buffer: %p (size: %u, aligned: %s)", aligned_input, input_size,
+           ((uintptr_t)aligned_input % 16 == 0) ? "YES" : "NO");
+  ESP_LOGI(TAG, "[DECODE DEBUG] Output buffer: %p (size: %u, aligned: %s)", aligned_output, output_size,
+           ((uintptr_t)aligned_output % 16 == 0) ? "YES" : "NO");
+  ESP_LOGI(TAG, "[DECODE DEBUG] Config: output_format=%d, rgb_order=%d", decode_cfg.output_format,
+           decode_cfg.rgb_order);
+  ESP_LOGI(TAG, "[DECODE DEBUG] Image dimensions: %dx%d", width, height);
+
   // Decode
   ret = jpeg_decoder_process(this->hw_decoder_, &decode_cfg, aligned_input, input_size, aligned_output, output_size,
                              &output_size);
 
   if (ret != ESP_OK) {
-    ESP_LOGE(TAG, "Hardware JPEG decode failed: %s", esp_err_to_name(ret));
+    ESP_LOGE(TAG, "Hardware JPEG decode failed: %s (error code: %d)", esp_err_to_name(ret), ret);
+    ESP_LOGE(TAG, "[DECODE DEBUG] Failed with decoder=%p, in=%p, in_size=%u, out=%p, out_size=%u", this->hw_decoder_,
+             aligned_input, input_size, aligned_output, output_size);
     free(aligned_input);
     free(aligned_output);
     return false;


### PR DESCRIPTION
…coder

Add detailed logging before jpeg_decoder_process() to diagnose ESP_ERR_INVALID_ARG:
- Decoder handle address
- Input/output buffer addresses and 16-byte alignment verification
- Buffer sizes
- Decoder config (output_format, rgb_order)
- Image dimensions
- Enhanced error logging with all parameters on failure

This will help identify exactly which parameter the hardware decoder is rejecting.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
