### PR TITLE
[picture_viewer] Fix hardware JPEG decoder struct initialization

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -445,11 +445,10 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
   // Copy input data to aligned buffer
   memcpy(aligned_input, jpeg_data.data(), input_size);
 
-  // Configure decoder
-  jpeg_decode_cfg_t decode_cfg = {
-      .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
-      .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_RGB,
-  };
+  // Configure decoder - use zero-init pattern to avoid struct corruption
+  jpeg_decode_cfg_t decode_cfg = {};
+  decode_cfg.output_format = JPEG_DECODE_OUT_FORMAT_RGB565;
+  decode_cfg.rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_RGB;
 
   // Debug: Log all parameters before decode
   ESP_LOGI(TAG, "[DECODE DEBUG] Decoder handle: %p", this->hw_decoder_);

--- a/esphome/components/picture_viewer/picture_viewer.h
+++ b/esphome/components/picture_viewer/picture_viewer.h
@@ -25,6 +25,7 @@
 #ifdef USE_HARDWARE_JPEG_DECODER
 // ESP32-P4: Use hardware JPEG decoder
 #include "driver/jpeg_decode.h"
+#include "driver/jpeg_types.h"
 #endif
 
 #ifdef USE_JPEGDEC


### PR DESCRIPTION
Fix ESP_ERR_INVALID_ARG error caused by struct corruption in JPEG decoder config.

Root cause: Using designated initializers with jpeg_decode_cfg_t was causing wrong values (output_format=33554434 instead of 0-2).

Solution:
1. Add missing #include "driver/jpeg_types.h" for proper type definitions
2. Change from designated initializers to zero-init pattern:
   - Before: jpeg_decode_cfg_t decode_cfg = { .output_format = ..., .rgb_order = ... };
   - After:  jpeg_decode_cfg_t decode_cfg = {}; decode_cfg.output_format = JPEG_DECODE_OUT_FORMAT_RGB565; decode_cfg.rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_RGB;

This matches the working pattern used in storage_images (commit 06190c6).

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
