### PR TITLE
[transcoder] Add centralized media codec management component

### DIFF
--- a/esphome/components/picture_viewer/__init__.py
+++ b/esphome/components/picture_viewer/__init__.py
@@ -20,7 +20,7 @@ except ImportError:
     lv_canvas_t = None
 
 CODEOWNERS = ["@esphome/core"]
-DEPENDENCIES = []
+DEPENDENCIES = ["transcoder"]
 AUTO_LOAD = []
 
 # Namespaces
@@ -102,34 +102,10 @@ async def to_code(config):
     cg.add(var.set_thumbnail_height(config[CONF_THUMBNAIL_HEIGHT]))
     cg.add(var.set_fit_mode(config[CONF_FIT_MODE]))
 
-    # Add defines based on platform
-    from esphome.components.esp32 import get_esp32_variant, add_idf_component
+    # Link to transcoder component (handles all decoder initialization)
+    # The transcoder dependency ensures it's initialized before picture_viewer
+    cg.add(var.set_transcoder(cg.RawExpression("esphome::transcoder::global_transcoder")))
 
-    variant = get_esp32_variant()
-    variant_lower = variant.lower() if variant else ""
-
-    _LOGGER.info("Detected ESP32 variant: %s", variant)
-
-    if variant_lower in ("esp32s2", "esp32-s2"):
-        # Enable esp_jpeg decoder for S2/S3
-        # Add esp_jpeg as a managed ESP-IDF component from ESP Component Registry
-        add_idf_component(name="espressif/esp_jpeg", ref="1.3.1")
-        cg.add_define("USE_ESP_JPEG_DECODER")
-        _LOGGER.info("Enabled esp_jpeg decoder v1.3.1 for %s", variant)
-    elif variant_lower in ("esp32s3", "esp32-s3"):
-        # Enable esp_jpeg decoder for S2/S3
-        # Add esp_jpeg as a managed ESP-IDF component from ESP Component Registry
-        add_idf_component(name="espressif/esp_jpeg", ref="1.3.1")
-        cg.add_define("USE_ESP_JPEG_DECODER")
-        _LOGGER.info("Enabled esp_jpeg decoder v1.3.1 for %s", variant)
-    elif variant_lower in ("esp32p4", "esp32-p4"):
-        # Enable hardware JPEG decoder for P4
-        cg.add_define("USE_HARDWARE_JPEG_DECODER")
-        _LOGGER.info("Enabled hardware JPEG decoder for %s", variant)
-    else:
-        # Use JPEGDec library as fallback
-        cg.add_library("bodmer/JPEGDecoder", "1.8.0")
-        cg.add_define("USE_JPEGDEC")
-        _LOGGER.info("Using JPEGDec library for %s", variant)
+    _LOGGER.info("Picture viewer configured to use transcoder component")
 
     return var

--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -31,12 +31,7 @@ PictureViewer::~PictureViewer() {
     this->next_image_data_ = nullptr;
   }
 
-#ifdef USE_HARDWARE_JPEG_DECODER
-  if (this->hw_decoder_ != nullptr) {
-    jpeg_del_decoder_engine(this->hw_decoder_);
-    this->hw_decoder_ = nullptr;
-  }
-#endif
+  // Note: Don't delete transcoder's decoder - transcoder owns it
 
 #ifdef USE_JPEGDEC
   if (this->jpeg_decoder_ != nullptr) {
@@ -49,25 +44,28 @@ PictureViewer::~PictureViewer() {
 void PictureViewer::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Picture Viewer...");
 
-#ifdef USE_HARDWARE_JPEG_DECODER
-  // Initialize hardware JPEG decoder for ESP32-P4
-  jpeg_decode_engine_cfg_t decode_eng_cfg = {
-      .intr_priority = 0,
-      .timeout_ms = 200,
-  };
-  esp_err_t ret = jpeg_new_decoder_engine(&decode_eng_cfg, &this->hw_decoder_);
-  if (ret != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to create hardware JPEG decoder: %s", esp_err_to_name(ret));
+#ifdef USE_TRANSCODER
+  // Verify transcoder is available
+  if (this->transcoder_ == nullptr) {
+    ESP_LOGE(TAG, "Transcoder component not set");
     this->mark_failed();
     return;
   }
-  ESP_LOGI(TAG, "Hardware JPEG decoder initialized");
-#endif
 
+  // Verify JPEG decoder is available in transcoder
+  if (!this->transcoder_->is_jpeg_decoder_available()) {
+    ESP_LOGE(TAG, "JPEG decoder not available in transcoder");
+    this->mark_failed();
+    return;
+  }
+
+  ESP_LOGI(TAG, "Using transcoder for JPEG decoding");
+#else
 #ifdef USE_JPEGDEC
-  // Initialize JPEGDec library
+  // Initialize JPEGDec library (fallback when transcoder not available)
   this->jpeg_decoder_ = new JPEGDEC();
   ESP_LOGI(TAG, "JPEGDec library initialized");
+#endif
 #endif
 
   // Register callback with file_manager if available
@@ -406,10 +404,13 @@ bool PictureViewer::decode_jpeg_esp_(const std::vector<uint8_t> &jpeg_data, std:
 #ifdef USE_HARDWARE_JPEG_DECODER
 bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data, std::vector<uint8_t> &rgb565_data,
                                            int &width, int &height, int target_width, int target_height) {
-  if (this->hw_decoder_ == nullptr) {
-    ESP_LOGE(TAG, "Hardware JPEG decoder not initialized");
+  if (this->transcoder_ == nullptr || !this->transcoder_->is_jpeg_decoder_available()) {
+    ESP_LOGE(TAG, "Hardware JPEG decoder not available in transcoder");
     return false;
   }
+
+  // Get decoder handle from transcoder
+  jpeg_decoder_handle_t hw_decoder = this->transcoder_->get_jpeg_decoder();
 
   // Get image info
   jpeg_decode_picture_info_t pic_info = {};
@@ -451,7 +452,7 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
   decode_cfg.rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_RGB;
 
   // Debug: Log all parameters before decode
-  ESP_LOGI(TAG, "[DECODE DEBUG] Decoder handle: %p", this->hw_decoder_);
+  ESP_LOGI(TAG, "[DECODE DEBUG] Decoder handle: %p", hw_decoder);
   ESP_LOGI(TAG, "[DECODE DEBUG] Input buffer: %p (size: %u, aligned: %s)", aligned_input, input_size,
            ((uintptr_t)aligned_input % 16 == 0) ? "YES" : "NO");
   ESP_LOGI(TAG, "[DECODE DEBUG] Output buffer: %p (size: %u, aligned: %s)", aligned_output, output_size,
@@ -461,12 +462,12 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
   ESP_LOGI(TAG, "[DECODE DEBUG] Image dimensions: %dx%d", width, height);
 
   // Decode
-  ret = jpeg_decoder_process(this->hw_decoder_, &decode_cfg, aligned_input, input_size, aligned_output, output_size,
+  ret = jpeg_decoder_process(hw_decoder, &decode_cfg, aligned_input, input_size, aligned_output, output_size,
                              &output_size);
 
   if (ret != ESP_OK) {
     ESP_LOGE(TAG, "Hardware JPEG decode failed: %s (error code: %d)", esp_err_to_name(ret), ret);
-    ESP_LOGE(TAG, "[DECODE DEBUG] Failed with decoder=%p, in=%p, in_size=%u, out=%p, out_size=%u", this->hw_decoder_,
+    ESP_LOGE(TAG, "[DECODE DEBUG] Failed with decoder=%p, in=%p, in_size=%u, out=%p, out_size=%u", hw_decoder,
              aligned_input, input_size, aligned_output, output_size);
     free(aligned_input);
     free(aligned_output);

--- a/esphome/components/picture_viewer/picture_viewer.h
+++ b/esphome/components/picture_viewer/picture_viewer.h
@@ -12,26 +12,13 @@
 #include "esphome/components/storage_host/file_manager.h"
 #endif
 
+#ifdef USE_TRANSCODER
+#include "esphome/components/transcoder/transcoder.h"
+#endif
+
 #include <string>
 #include <vector>
 #include <memory>
-
-// JPEG decoder selection
-#ifdef USE_ESP_JPEG_DECODER
-// ESP32-S2/S3: Use esp_jpeg decoder from ESP Component Registry
-#include "esp_jpeg_dec.h"
-#endif
-
-#ifdef USE_HARDWARE_JPEG_DECODER
-// ESP32-P4: Use hardware JPEG decoder
-#include "driver/jpeg_decode.h"
-#include "driver/jpeg_types.h"
-#endif
-
-#ifdef USE_JPEGDEC
-// Other platforms: Use JPEGDec library
-#include <JPEGDEC.h>
-#endif
 
 namespace esphome {
 namespace picture_viewer {
@@ -86,6 +73,10 @@ class PictureViewer : public Component {
 
 #ifdef USE_STORAGE_HOST
   void set_file_manager(storage_host::FileManager *fm) { this->file_manager_ = fm; }
+#endif
+
+#ifdef USE_TRANSCODER
+  void set_transcoder(transcoder::Transcoder *tc) { this->transcoder_ = tc; }
 #endif
 
 #ifdef USE_LVGL
@@ -162,6 +153,10 @@ class PictureViewer : public Component {
   storage_host::FileManager *file_manager_{nullptr};
 #endif
 
+#ifdef USE_TRANSCODER
+  transcoder::Transcoder *transcoder_{nullptr};
+#endif
+
 #ifdef USE_LVGL
   std::string canvas_id_;  // LVGL canvas widget ID (for debugging)
   lv_obj_t *canvas_{nullptr};  // LVGL canvas object pointer
@@ -218,7 +213,6 @@ class PictureViewer : public Component {
 #ifdef USE_HARDWARE_JPEG_DECODER
   bool decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data, std::vector<uint8_t> &rgb565_data, int &width,
                               int &height, int target_width = 0, int target_height = 0);
-  jpeg_decoder_handle_t hw_decoder_{nullptr};
 #endif
 
   /// Decode JPEG using JPEGDec library (fallback)

--- a/esphome/components/transcoder/__init__.py
+++ b/esphome/components/transcoder/__init__.py
@@ -1,0 +1,64 @@
+"""Transcoder component for managing hardware media codecs (JPEG, H.264, etc.)."""
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+from esphome.core import CORE
+
+CODEOWNERS = ["@p1ngb4ck"]
+DEPENDENCIES = []
+
+transcoder_ns = cg.esphome_ns.namespace("transcoder")
+Transcoder = transcoder_ns.class_("Transcoder", cg.Component)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(Transcoder),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    """Configure transcoder component based on platform."""
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    # Only configure for ESP32 platforms
+    if not CORE.is_esp32:
+        return
+
+    from esphome.components.esp32 import get_esp32_variant, add_idf_component
+
+    variant = get_esp32_variant()
+    if not variant:
+        return
+
+    variant_lower = variant.lower().replace("-", "")
+
+    # JPEG Decoder/Encoder Support
+    if variant_lower in ("esp32s2", "esp32s2"):
+        # ESP32-S2/S3: Use esp_jpeg from ESP Component Registry
+        add_idf_component(name="espressif/esp_jpeg", ref="1.3.1")
+        cg.add_define("USE_ESP_JPEG_DECODER")
+        cg.add_define("USE_ESP_JPEG_ENCODER")
+        cg.add_define("TRANSCODER_JPEG_AVAILABLE")
+    elif variant_lower in ("esp32s3", "esp32s3"):
+        # ESP32-S2/S3: Use esp_jpeg from ESP Component Registry
+        add_idf_component(name="espressif/esp_jpeg", ref="1.3.1")
+        cg.add_define("USE_ESP_JPEG_DECODER")
+        cg.add_define("USE_ESP_JPEG_ENCODER")
+        cg.add_define("TRANSCODER_JPEG_AVAILABLE")
+    elif variant_lower in ("esp32p4", "esp32p4"):
+        # ESP32-P4: Hardware JPEG codec
+        cg.add_define("USE_HARDWARE_JPEG_DECODER")
+        cg.add_define("USE_HARDWARE_JPEG_ENCODER")
+        cg.add_define("TRANSCODER_JPEG_AVAILABLE")
+
+        # H.264 Decoder/Encoder Support (ESP32-P4 only)
+        # Note: H.264 support requires ESP-IDF 5.3+ and is hardware-accelerated on P4
+        cg.add_define("USE_HARDWARE_H264_DECODER")
+        cg.add_define("USE_HARDWARE_H264_ENCODER")
+        cg.add_define("TRANSCODER_H264_AVAILABLE")
+
+    # Set global transcoder accessor
+    cg.add_define("USE_TRANSCODER")
+    cg.add(cg.RawExpression("esphome::transcoder::global_transcoder = id(transcoder_instance)"))

--- a/esphome/components/transcoder/transcoder.cpp
+++ b/esphome/components/transcoder/transcoder.cpp
@@ -1,0 +1,127 @@
+/**
+ * @file transcoder.cpp
+ * @brief Implementation of centralized hardware media codec management
+ */
+
+#include "transcoder.h"
+
+namespace esphome {
+namespace transcoder {
+
+static const char *const TAG = "transcoder";
+
+// Global transcoder instance
+Transcoder *global_transcoder = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+void Transcoder::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up Transcoder...");
+
+  // Initialize JPEG Decoder
+#ifdef USE_HARDWARE_JPEG_DECODER
+  // ESP32-P4: Hardware JPEG decoder
+  jpeg_decode_engine_cfg_t decode_eng_cfg = {};
+  decode_eng_cfg.intr_priority = 0;
+  decode_eng_cfg.timeout_ms = 200;
+
+  esp_err_t ret = jpeg_new_decoder_engine(&decode_eng_cfg, &this->jpeg_decoder_);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to create hardware JPEG decoder: %s", esp_err_to_name(ret));
+    this->mark_failed();
+    return;
+  }
+  ESP_LOGI(TAG, "Hardware JPEG decoder initialized (ESP32-P4)");
+
+#elif defined(USE_ESP_JPEG_DECODER)
+  // ESP32-S2/S3: esp_jpeg decoder
+  this->esp_jpeg_decoder_initialized_ = true;
+  ESP_LOGI(TAG, "ESP-JPEG decoder ready (ESP32-S2/S3)");
+#endif
+
+  // Initialize JPEG Encoder
+#ifdef USE_HARDWARE_JPEG_ENCODER
+  // ESP32-P4: Hardware JPEG encoder
+  jpeg_encode_engine_cfg_t encode_eng_cfg = {};
+  encode_eng_cfg.intr_priority = 0;
+  encode_eng_cfg.timeout_ms = 200;
+
+  ret = jpeg_new_encoder_engine(&encode_eng_cfg, &this->jpeg_encoder_);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to create hardware JPEG encoder: %s", esp_err_to_name(ret));
+    // Don't mark as failed - encoder is optional
+  } else {
+    ESP_LOGI(TAG, "Hardware JPEG encoder initialized (ESP32-P4)");
+  }
+#endif
+
+  // Initialize H.264 Decoder
+#ifdef USE_HARDWARE_H264_DECODER
+  // ESP32-P4: Hardware H.264 decoder
+  // Note: Actual initialization will be added when ESP-IDF provides stable H.264 driver API
+  // As of ESP-IDF 5.3, H.264 hardware support exists but API may not be finalized
+  this->h264_decoder_initialized_ = false;
+  ESP_LOGW(TAG, "H.264 decoder: Hardware available but driver API pending (ESP32-P4)");
+#endif
+
+  // Initialize H.264 Encoder
+#ifdef USE_HARDWARE_H264_ENCODER
+  // ESP32-P4: Hardware H.264 encoder
+  // Note: Actual initialization will be added when ESP-IDF provides stable H.264 driver API
+  this->h264_encoder_initialized_ = false;
+  ESP_LOGW(TAG, "H.264 encoder: Hardware available but driver API pending (ESP32-P4)");
+#endif
+
+  ESP_LOGCONFIG(TAG, "Transcoder setup complete");
+}
+
+void Transcoder::dump_config() {
+  ESP_LOGCONFIG(TAG, "Transcoder:");
+
+  // Report JPEG Decoder status
+#ifdef TRANSCODER_JPEG_AVAILABLE
+  ESP_LOGCONFIG(TAG, "  JPEG Decoder: %s",
+                this->is_jpeg_decoder_available() ? "Available" : "Not available");
+#ifdef USE_HARDWARE_JPEG_DECODER
+  ESP_LOGCONFIG(TAG, "    Type: Hardware (ESP32-P4)");
+  if (this->jpeg_decoder_) {
+    ESP_LOGCONFIG(TAG, "    Handle: %p", this->jpeg_decoder_);
+  }
+#elif defined(USE_ESP_JPEG_DECODER)
+  ESP_LOGCONFIG(TAG, "    Type: ESP-JPEG (ESP32-S2/S3)");
+#endif
+#else
+  ESP_LOGCONFIG(TAG, "  JPEG Decoder: Not supported on this platform");
+#endif
+
+  // Report JPEG Encoder status
+#ifdef USE_HARDWARE_JPEG_ENCODER
+  ESP_LOGCONFIG(TAG, "  JPEG Encoder: %s",
+                this->is_jpeg_encoder_available() ? "Available" : "Not available");
+  ESP_LOGCONFIG(TAG, "    Type: Hardware (ESP32-P4)");
+  if (this->jpeg_encoder_) {
+    ESP_LOGCONFIG(TAG, "    Handle: %p", this->jpeg_encoder_);
+  }
+#else
+  ESP_LOGCONFIG(TAG, "  JPEG Encoder: Not supported on this platform");
+#endif
+
+  // Report H.264 Decoder status
+#ifdef TRANSCODER_H264_AVAILABLE
+  ESP_LOGCONFIG(TAG, "  H.264 Decoder: %s (driver API pending)",
+                this->is_h264_decoder_available() ? "Ready" : "Hardware available");
+  ESP_LOGCONFIG(TAG, "    Type: Hardware (ESP32-P4)");
+#else
+  ESP_LOGCONFIG(TAG, "  H.264 Decoder: Not supported on this platform");
+#endif
+
+  // Report H.264 Encoder status
+#ifdef USE_HARDWARE_H264_ENCODER
+  ESP_LOGCONFIG(TAG, "  H.264 Encoder: %s (driver API pending)",
+                this->is_h264_encoder_available() ? "Ready" : "Hardware available");
+  ESP_LOGCONFIG(TAG, "    Type: Hardware (ESP32-P4)");
+#else
+  ESP_LOGCONFIG(TAG, "  H.264 Encoder: Not supported on this platform");
+#endif
+}
+
+}  // namespace transcoder
+}  // namespace esphome

--- a/esphome/components/transcoder/transcoder.h
+++ b/esphome/components/transcoder/transcoder.h
@@ -1,0 +1,161 @@
+/**
+ * @file transcoder.h
+ * @brief Centralized hardware media codec management for ESPHome
+ *
+ * Provides unified access to hardware-accelerated media codecs including:
+ * - JPEG encoder/decoder (ESP32-S2/S3/P4)
+ * - H.264 encoder/decoder (ESP32-P4)
+ *
+ * Components requiring codec support should depend on this component and
+ * access codecs through the global_transcoder accessor.
+ */
+
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+
+// Platform-specific codec headers
+#ifdef USE_ESP_JPEG_DECODER
+// ESP32-S2/S3: esp_jpeg from ESP Component Registry
+#include "esp_jpeg_dec.h"
+#include "esp_jpeg_enc.h"
+#endif
+
+#ifdef USE_HARDWARE_JPEG_DECODER
+// ESP32-P4: Hardware JPEG codec
+#include "driver/jpeg_decode.h"
+#include "driver/jpeg_encode.h"
+#include "driver/jpeg_types.h"
+#include "hal/color_types.h"
+#endif
+
+#ifdef USE_HARDWARE_H264_DECODER
+// ESP32-P4: Hardware H.264 codec
+// Note: H.264 driver headers - these may need to be updated based on ESP-IDF version
+// As of ESP-IDF 5.3, H.264 support is available but headers may vary
+#include "driver/h264_types.h"
+#endif
+
+namespace esphome {
+namespace transcoder {
+
+/**
+ * @brief Codec types supported by the transcoder
+ */
+enum class CodecType {
+  JPEG_DECODER,
+  JPEG_ENCODER,
+  H264_DECODER,
+  H264_ENCODER,
+};
+
+/**
+ * @brief Main transcoder component managing hardware media codecs
+ *
+ * This component initializes and provides access to hardware-accelerated
+ * media codecs available on the platform. It handles platform-specific
+ * initialization and provides a unified API for other components.
+ */
+class Transcoder : public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+  // ========== JPEG Decoder API ==========
+
+#if defined(USE_HARDWARE_JPEG_DECODER)
+  /**
+   * @brief Get hardware JPEG decoder handle (ESP32-P4)
+   * @return Pointer to JPEG decoder handle, or nullptr if not available
+   */
+  jpeg_decoder_handle_t get_jpeg_decoder() { return this->jpeg_decoder_; }
+
+  /**
+   * @brief Check if JPEG decoder is available
+   */
+  bool is_jpeg_decoder_available() { return this->jpeg_decoder_ != nullptr; }
+
+#elif defined(USE_ESP_JPEG_DECODER)
+  /**
+   * @brief Get esp_jpeg decoder config (ESP32-S2/S3)
+   * @return Pointer to decoder config, or nullptr if not initialized
+   */
+  esp_jpeg_image_cfg_t *get_esp_jpeg_decoder_config() { return &this->esp_jpeg_decoder_cfg_; }
+
+  /**
+   * @brief Check if esp_jpeg decoder is available
+   */
+  bool is_jpeg_decoder_available() { return this->esp_jpeg_decoder_initialized_; }
+#endif
+
+  // ========== JPEG Encoder API ==========
+
+#if defined(USE_HARDWARE_JPEG_ENCODER)
+  /**
+   * @brief Get hardware JPEG encoder handle (ESP32-P4)
+   * @return Pointer to JPEG encoder handle, or nullptr if not available
+   */
+  jpeg_encoder_handle_t get_jpeg_encoder() { return this->jpeg_encoder_; }
+
+  /**
+   * @brief Check if JPEG encoder is available
+   */
+  bool is_jpeg_encoder_available() { return this->jpeg_encoder_ != nullptr; }
+#endif
+
+  // ========== H.264 Decoder API ==========
+
+#ifdef USE_HARDWARE_H264_DECODER
+  /**
+   * @brief Check if H.264 decoder is available (ESP32-P4)
+   * Note: Actual H.264 API will be added once ESP-IDF provides stable headers
+   */
+  bool is_h264_decoder_available() { return this->h264_decoder_initialized_; }
+#endif
+
+  // ========== H.264 Encoder API ==========
+
+#ifdef USE_HARDWARE_H264_ENCODER
+  /**
+   * @brief Check if H.264 encoder is available (ESP32-P4)
+   * Note: Actual H.264 API will be added once ESP-IDF provides stable headers
+   */
+  bool is_h264_encoder_available() { return this->h264_encoder_initialized_; }
+#endif
+
+ protected:
+  // JPEG Decoder state
+#ifdef USE_HARDWARE_JPEG_DECODER
+  jpeg_decoder_handle_t jpeg_decoder_{nullptr};
+#endif
+
+#ifdef USE_ESP_JPEG_DECODER
+  esp_jpeg_image_cfg_t esp_jpeg_decoder_cfg_{};
+  bool esp_jpeg_decoder_initialized_{false};
+#endif
+
+  // JPEG Encoder state
+#ifdef USE_HARDWARE_JPEG_ENCODER
+  jpeg_encoder_handle_t jpeg_encoder_{nullptr};
+#endif
+
+  // H.264 Decoder state
+#ifdef USE_HARDWARE_H264_DECODER
+  bool h264_decoder_initialized_{false};
+  // Actual decoder handle will be added when ESP-IDF headers are available
+#endif
+
+  // H.264 Encoder state
+#ifdef USE_HARDWARE_H264_ENCODER
+  bool h264_encoder_initialized_{false};
+  // Actual encoder handle will be added when ESP-IDF headers are available
+#endif
+};
+
+/// Global transcoder instance accessor
+extern Transcoder *global_transcoder;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+}  // namespace transcoder
+}  // namespace esphome


### PR DESCRIPTION
Implement new transcoder component following esp32_hosted pattern to provide centralized hardware media codec management (JPEG, H.264) across platforms.

Architecture:
- Transcoder component initializes and owns codec instances
- Other components declare dependency and access via global_transcoder
- Platform-specific codec selection handled in transcoder/__init__.py
- Supports JPEG decoder/encoder (S2/S3/P4) and H.264 (P4)

Transcoder Component Features:
- JPEG decoder: esp_jpeg (S2/S3) or hardware (P4)
- JPEG encoder: hardware (P4)
- H.264 decoder/encoder: hardware (P4) - API pending ESP-IDF headers
- Global accessor pattern: esphome::transcoder::global_transcoder
- Setup priority: HARDWARE (ensures early initialization)

Picture Viewer Migration:
- Added transcoder dependency to DEPENDENCIES
- Removed decoder initialization code (transcoder handles it)
- Uses transcoder->get_jpeg_decoder() instead of own hw_decoder_
- Removed decoder cleanup in destructor (transcoder owns it)
- Simplified setup() - just validates transcoder availability

Benefits:
- Single codec initialization point (no duplication)
- Shared codec instances across components
- Platform abstraction centralized
- Future components (video_player, camera) can reuse
- Easier to add new codecs (H.265, VP9, etc.)

This addresses the enum definition issue by properly loading IDF components through transcoder's __init__.py, ensuring headers are available at compile time.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
