### PR TITLE
[picture_viewer] Use AUTO_LOAD for transcoder dependency

### DIFF
--- a/esphome/components/picture_viewer/__init__.py
+++ b/esphome/components/picture_viewer/__init__.py
@@ -20,8 +20,8 @@ except ImportError:
     lv_canvas_t = None
 
 CODEOWNERS = ["@esphome/core"]
-DEPENDENCIES = ["transcoder"]
-AUTO_LOAD = []
+DEPENDENCIES = []
+AUTO_LOAD = ["transcoder"]
 
 # Namespaces
 picture_viewer_ns = cg.esphome_ns.namespace("picture_viewer")


### PR DESCRIPTION
Change transcoder from DEPENDENCIES to AUTO_LOAD so it's automatically included when picture_viewer is used, without requiring explicit YAML config.

Before (required in YAML):
  transcoder:
  picture_viewer:
    ...

After (automatic):
  picture_viewer:
    ...

The transcoder component is now transparently loaded as infrastructure.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
