### PR TITLE
[transcoder] Fix global accessor assignment for AUTO_LOAD

### DIFF
--- a/esphome/components/transcoder/__init__.py
+++ b/esphome/components/transcoder/__init__.py
@@ -173,6 +173,6 @@ async def to_code(config):
                 "H.264 codec requested but only available on ESP32-P4/S3 (current: %s)", variant
             )
 
-    # Set global transcoder accessor
+    # Set global transcoder accessor using the var we created
     cg.add_define("USE_TRANSCODER")
-    cg.add(cg.RawExpression("esphome::transcoder::global_transcoder = id(transcoder_instance)"))
+    cg.add(cg.RawStatement(f"esphome::transcoder::global_transcoder = {var};"))


### PR DESCRIPTION
Fix compilation error when transcoder is AUTO_LOAD'ed:
  error: 'transcoder_instance' was not declared in this scope

Issue: Using id(transcoder_instance) doesn't work when component is
AUTO_LOAD'ed because there's no explicit transcoder: config in YAML.

Solution: Use the var directly instead of id() reference.

Before (broken):
  cg.add(cg.RawExpression("esphome::transcoder::global_transcoder = id(transcoder_instance)"))

After (working):
  cg.add(cg.RawStatement(f"esphome::transcoder::global_transcoder = {var};"))

This assigns the actual Pvariable pointer created by to_code() to the global accessor, working correctly whether transcoder is explicit or AUTO_LOAD'ed.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
