### PR TITLE
[transcoder] Fix global accessor to use constructor pattern

### DIFF
--- a/esphome/components/transcoder/__init__.py
+++ b/esphome/components/transcoder/__init__.py
@@ -173,6 +173,6 @@ async def to_code(config):
                 "H.264 codec requested but only available on ESP32-P4/S3 (current: %s)", variant
             )
 
-    # Set global transcoder accessor using the var we created
+    # Set global transcoder accessor flag
+    # Note: global_transcoder is set to 'this' in Transcoder constructor
     cg.add_define("USE_TRANSCODER")
-    cg.add(cg.RawStatement(f"esphome::transcoder::global_transcoder = {var};"))

--- a/esphome/components/transcoder/transcoder.cpp
+++ b/esphome/components/transcoder/transcoder.cpp
@@ -13,6 +13,8 @@ static const char *const TAG = "transcoder";
 // Global transcoder instance
 Transcoder *global_transcoder = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+Transcoder::Transcoder() { global_transcoder = this; }
+
 void Transcoder::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Transcoder...");
 


### PR DESCRIPTION
Follow ESPHome convention for global accessors by setting in constructor instead of via Python codegen, matching api/logger pattern.

Issue: Previous attempt to set global_transcoder via Python RawStatement was incorrect - var is a MockObj and doesn't stringify correctly.

Solution: Set global_transcoder in Transcoder constructor like APIServer:

C++ (transcoder.cpp):
  Transcoder::Transcoder() { global_transcoder = this; }

This ensures global_transcoder is always set correctly regardless of whether transcoder is explicit in YAML or AUTO_LOAD'ed.

Removed Python code:
  cg.add(cg.RawStatement(f"esphome::transcoder::global_transcoder = {var};"))

This is the standard ESPHome pattern for component global accessors.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
