### PR TITLE
[transcoder] Add constructor declaration to header

### DIFF
--- a/esphome/components/transcoder/transcoder.h
+++ b/esphome/components/transcoder/transcoder.h
@@ -61,6 +61,7 @@ enum class CodecType {
  */
 class Transcoder : public Component {
  public:
+  Transcoder();
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }


### PR DESCRIPTION
Fix compilation error by declaring constructor in header file.

Error: definition of implicitly-declared constructor
Fix: Added 'Transcoder();' declaration to public section of class.

The constructor implementation in .cpp sets global_transcoder = this following the ESPHome pattern used by APIServer and Logger components.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
