### PR TITLE
[picture_viewer] Add compile-time diagnostics for JPEG enum values

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -20,6 +20,18 @@ namespace picture_viewer {
 
 static const char *const TAG = "picture_viewer";
 
+#ifdef USE_HARDWARE_JPEG_DECODER
+// Compile-time diagnostic: Check what value the enum actually has
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#pragma message("JPEG_DECODE_OUT_FORMAT_RGB565 = " TOSTRING(JPEG_DECODE_OUT_FORMAT_RGB565))
+#ifdef ESP_COLOR_FOURCC_RGB16_BE
+#pragma message("ESP_COLOR_FOURCC_RGB16_BE defined")
+#else
+#pragma message("ESP_COLOR_FOURCC_RGB16_BE NOT defined!")
+#endif
+#endif
+
 // =====================================================
 // Component Lifecycle
 // =====================================================


### PR DESCRIPTION
Add pragma messages to check what value JPEG_DECODE_OUT_FORMAT_RGB565 has at compile time and whether ESP_COLOR_FOURCC_RGB16_BE is defined.

This will help diagnose why output_format has wrong value (33554434).

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
