### PR TITLE
[picture_viewer] Try BGR order and explicitly set conv_std

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -464,10 +464,11 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
   // Copy input data to aligned buffer
   memcpy(aligned_input, jpeg_data.data(), input_size);
 
-  // Configure decoder - use zero-init pattern to avoid struct corruption
+  // Configure decoder
   jpeg_decode_cfg_t decode_cfg = {};
   decode_cfg.output_format = JPEG_DECODE_OUT_FORMAT_RGB565;
-  decode_cfg.rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_RGB;
+  decode_cfg.rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR;  // Try BGR (little endian)
+  decode_cfg.conv_std = JPEG_YUV_RGB_CONV_STD_BT601;       // Explicitly set BT601
 
   // Debug: Log all parameters before decode
   ESP_LOGI(TAG, "[DECODE DEBUG] Decoder handle: %p", hw_decoder);
@@ -475,8 +476,8 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
            ((uintptr_t)aligned_input % 16 == 0) ? "YES" : "NO");
   ESP_LOGI(TAG, "[DECODE DEBUG] Output buffer: %p (size: %u, aligned: %s)", aligned_output, output_size,
            ((uintptr_t)aligned_output % 16 == 0) ? "YES" : "NO");
-  ESP_LOGI(TAG, "[DECODE DEBUG] Config: output_format=%d, rgb_order=%d", decode_cfg.output_format,
-           decode_cfg.rgb_order);
+  ESP_LOGI(TAG, "[DECODE DEBUG] Config: output_format=%d, rgb_order=%d, conv_std=%d", decode_cfg.output_format,
+           decode_cfg.rgb_order, decode_cfg.conv_std);
   ESP_LOGI(TAG, "[DECODE DEBUG] Image dimensions: %dx%d", width, height);
 
   // Decode


### PR DESCRIPTION
Change rgb_order from RGB (big endian) to BGR (little endian) as the decoder might expect little-endian RGB565 format.

Also explicitly set conv_std to BT601 instead of relying on zero-init.

Added conv_std to debug output to see all three config values.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
