### PR TITLE
[picture_viewer] Add YAML configuration for JPEG decoder parameters

### DIFF
--- a/esphome/components/picture_viewer/__init__.py
+++ b/esphome/components/picture_viewer/__init__.py
@@ -44,6 +44,23 @@ IMAGE_FIT_MODES = {
     "CENTER": ImageFitMode.CENTER,
 }
 
+# JPEG decoder configuration enums
+JPEG_RGB_ORDER = {
+    "RGB": 0,  # Big endian
+    "BGR": 1,  # Little endian
+}
+
+JPEG_COLOR_SPACE = {
+    "BT601": 0,
+    "BT709": 1,
+}
+
+JPEG_OUTPUT_FORMAT = {
+    "RGB888": 0x02000000,  # COLOR_TYPE_ID(COLOR_SPACE_RGB, COLOR_PIXEL_RGB888)
+    "RGB565": 0x02000002,  # COLOR_TYPE_ID(COLOR_SPACE_RGB, COLOR_PIXEL_RGB565)
+    "GRAY": 0x03000000,    # COLOR_TYPE_ID(COLOR_SPACE_GRAY, COLOR_PIXEL_GRAY8)
+}
+
 # Configuration keys
 CONF_FILE_MANAGER_ID = "file_manager_id"
 CONF_CANVAS_ID = "canvas_id"
@@ -54,6 +71,9 @@ CONF_ENABLE_THUMBNAILS = "enable_thumbnails"
 CONF_THUMBNAIL_WIDTH = "thumbnail_width"
 CONF_THUMBNAIL_HEIGHT = "thumbnail_height"
 CONF_FIT_MODE = "fit_mode"
+CONF_JPEG_RGB_ORDER = "jpeg_rgb_order"
+CONF_JPEG_COLOR_SPACE = "jpeg_color_space"
+CONF_JPEG_OUTPUT_FORMAT = "jpeg_output_format"
 
 # Component configuration
 CONFIG_SCHEMA = cv.Schema(
@@ -71,6 +91,15 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_THUMBNAIL_HEIGHT, default=90): cv.int_range(min=32, max=240),
         cv.Optional(CONF_FIT_MODE, default="SCALE_TO_FIT"): cv.enum(
             IMAGE_FIT_MODES, upper=True
+        ),
+        cv.Optional(CONF_JPEG_RGB_ORDER, default="BGR"): cv.enum(
+            JPEG_RGB_ORDER, upper=True
+        ),
+        cv.Optional(CONF_JPEG_COLOR_SPACE, default="BT601"): cv.enum(
+            JPEG_COLOR_SPACE, upper=True
+        ),
+        cv.Optional(CONF_JPEG_OUTPUT_FORMAT, default="RGB565"): cv.enum(
+            JPEG_OUTPUT_FORMAT, upper=True
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -106,6 +135,11 @@ async def to_code(config):
     cg.add(var.set_thumbnail_width(config[CONF_THUMBNAIL_WIDTH]))
     cg.add(var.set_thumbnail_height(config[CONF_THUMBNAIL_HEIGHT]))
     cg.add(var.set_fit_mode(config[CONF_FIT_MODE]))
+
+    # JPEG decoder configuration
+    cg.add(var.set_jpeg_rgb_order(config[CONF_JPEG_RGB_ORDER]))
+    cg.add(var.set_jpeg_color_space(config[CONF_JPEG_COLOR_SPACE]))
+    cg.add(var.set_jpeg_output_format(config[CONF_JPEG_OUTPUT_FORMAT]))
 
     # Link to transcoder component (handles all decoder initialization)
     # The transcoder dependency ensures it's initialized before picture_viewer

--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -464,11 +464,11 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
   // Copy input data to aligned buffer
   memcpy(aligned_input, jpeg_data.data(), input_size);
 
-  // Configure decoder
+  // Configure decoder using YAML-configured values
   jpeg_decode_cfg_t decode_cfg = {};
-  decode_cfg.output_format = JPEG_DECODE_OUT_FORMAT_RGB565;
-  decode_cfg.rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR;  // Try BGR (little endian)
-  decode_cfg.conv_std = JPEG_YUV_RGB_CONV_STD_BT601;       // Explicitly set BT601
+  decode_cfg.output_format = static_cast<jpeg_dec_output_format_t>(this->jpeg_output_format_);
+  decode_cfg.rgb_order = static_cast<jpeg_dec_rgb_element_order_t>(this->jpeg_rgb_order_);
+  decode_cfg.conv_std = static_cast<jpeg_yuv_rgb_conv_std_t>(this->jpeg_color_space_);
 
   // Debug: Log all parameters before decode
   ESP_LOGI(TAG, "[DECODE DEBUG] Decoder handle: %p", hw_decoder);
@@ -476,8 +476,8 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
            ((uintptr_t)aligned_input % 16 == 0) ? "YES" : "NO");
   ESP_LOGI(TAG, "[DECODE DEBUG] Output buffer: %p (size: %u, aligned: %s)", aligned_output, output_size,
            ((uintptr_t)aligned_output % 16 == 0) ? "YES" : "NO");
-  ESP_LOGI(TAG, "[DECODE DEBUG] Config: output_format=%d, rgb_order=%d, conv_std=%d", decode_cfg.output_format,
-           decode_cfg.rgb_order, decode_cfg.conv_std);
+  ESP_LOGI(TAG, "[DECODE DEBUG] Config: output_format=0x%08x (%u), rgb_order=%d, conv_std=%d",
+           this->jpeg_output_format_, this->jpeg_output_format_, this->jpeg_rgb_order_, this->jpeg_color_space_);
   ESP_LOGI(TAG, "[DECODE DEBUG] Image dimensions: %dx%d", width, height);
 
   // Decode

--- a/esphome/components/picture_viewer/picture_viewer.h
+++ b/esphome/components/picture_viewer/picture_viewer.h
@@ -92,6 +92,11 @@ class PictureViewer : public Component {
   void set_enable_thumbnails(bool enable) { this->enable_thumbnails_ = enable; }
   void set_fit_mode(ImageFitMode mode) { this->fit_mode_ = mode; }
 
+  // JPEG decoder configuration
+  void set_jpeg_rgb_order(int order) { this->jpeg_rgb_order_ = order; }
+  void set_jpeg_color_space(int color_space) { this->jpeg_color_space_ = color_space; }
+  void set_jpeg_output_format(uint32_t format) { this->jpeg_output_format_ = format; }
+
   // =====================================================
   // Picture Control API
   // =====================================================
@@ -169,6 +174,11 @@ class PictureViewer : public Component {
   int thumbnail_height_{90};
   bool enable_thumbnails_{true};
   ImageFitMode fit_mode_{ImageFitMode::SCALE_TO_FIT};  // Default: scale to fit
+
+  // JPEG decoder configuration
+  int jpeg_rgb_order_{1};        // Default: BGR (little endian)
+  int jpeg_color_space_{0};      // Default: BT601
+  uint32_t jpeg_output_format_{0x02000002};  // Default: RGB565
 
   // State
   std::vector<ImageEntry> images_;


### PR DESCRIPTION
Add three missing YAML configuration parameters that were removed:

1. jpeg_rgb_order (RGB/BGR) - Controls endianness (big/little endian) Default: BGR (little endian)

2. jpeg_color_space (BT601/BT709) - Color conversion standard Default: BT601

3. jpeg_output_format (RGB888/RGB565/GRAY) - Output pixel format Default: RGB565

These were previously hardcoded but should be configurable via YAML to allow users to match their display/LVGL requirements.

The enum values match ESP-IDF 5.5.1 COLOR_TYPE_ID format:
- RGB565 = 0x02000002 (COLOR_TYPE_ID(COLOR_SPACE_RGB, COLOR_PIXEL_RGB565))
- RGB888 = 0x02000000 (COLOR_TYPE_ID(COLOR_SPACE_RGB, COLOR_PIXEL_RGB888))
- GRAY = 0x03000000 (COLOR_TYPE_ID(COLOR_SPACE_GRAY, COLOR_PIXEL_GRAY8))

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
