### PR TITLE
[picture_viewer] Change default jpeg_rgb_order from BGR to RGB

### DIFF
--- a/esphome/components/picture_viewer/__init__.py
+++ b/esphome/components/picture_viewer/__init__.py
@@ -79,7 +79,7 @@ CONF_JPEG_OUTPUT_FORMAT = "jpeg_output_format"
 # Directory configuration schema
 DIRECTORY_SCHEMA = cv.Schema({
     cv.Required(CONF_PATH): cv.string,
-    cv.Optional(CONF_JPEG_RGB_ORDER, default="BGR"): cv.enum(JPEG_RGB_ORDER, upper=True),
+    cv.Optional(CONF_JPEG_RGB_ORDER, default="RGB"): cv.enum(JPEG_RGB_ORDER, upper=True),  # Changed default to RGB
     cv.Optional(CONF_JPEG_COLOR_SPACE, default="BT601"): cv.enum(JPEG_COLOR_SPACE, upper=True),
     cv.Optional(CONF_JPEG_OUTPUT_FORMAT, default="RGB565"): cv.enum(JPEG_OUTPUT_FORMAT, upper=True),
 })

--- a/esphome/components/picture_viewer/picture_viewer.h
+++ b/esphome/components/picture_viewer/picture_viewer.h
@@ -29,7 +29,7 @@ class PictureViewer;
 // Directory configuration with per-directory JPEG decoder settings
 struct DirectoryConfig {
   std::string path;
-  int jpeg_rgb_order{1};        // Default: BGR (little endian)
+  int jpeg_rgb_order{0};        // Default: RGB (big endian)
   int jpeg_color_space{0};      // Default: BT601
   uint32_t jpeg_output_format{0x02000002};  // Default: RGB565
 };


### PR DESCRIPTION
Change default from BGR (little endian) to RGB (big endian).

User confirmed they had RGB565 working before with the old storage_image component, so RGB order should be the correct default.

This changes:
- Python default: BGR -> RGB
- C++ default: 1 -> 0
- Comments updated to reflect RGB (big endian) as default

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
