### PR TITLE
[picture_viewer] Add 16-byte alignment padding for JPEG output buffer

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -453,7 +453,14 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
 
   // Calculate buffer sizes
   uint32_t input_size = jpeg_data.size();
-  uint32_t output_size = width * height * 2;  // RGB565 = 2 bytes per pixel
+
+  // Calculate output size with 16-byte alignment padding (JPEG protocol requirement)
+  // Width and height may be padded to 16-byte boundary by hardware
+  uint32_t aligned_width = (width + 15) & ~15;
+  uint32_t aligned_height = (height + 15) & ~15;
+  uint32_t output_size = aligned_width * aligned_height * 2;  // RGB565 = 2 bytes per pixel
+
+  ESP_LOGD(TAG, "Buffer sizes: input=%u, output=%u (aligned %ux%u)", input_size, output_size, aligned_width, aligned_height);
 
   // Allocate 16-byte aligned buffers (hardware requirement)
   uint8_t *aligned_input = (uint8_t *) heap_caps_aligned_alloc(16, input_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);


### PR DESCRIPTION
The ESP32-P4 JPEG decoder requires output buffer to be sized for 16-byte aligned dimensions per JPEG protocol requirements.

Calculate aligned dimensions:
- aligned_width = (width + 15) & ~15
- aligned_height = (height + 15) & ~15
- output_size = aligned_width * aligned_height * 2

Added debug logging to show actual vs aligned buffer sizes.

This may fix ESP_ERR_INVALID_ARG if decoder was rejecting undersized buffer.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
