### PR TITLE
[picture_viewer] Test: Use hardcoded constants matching old working code

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -447,6 +447,8 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
   }
 
   ESP_LOGD(TAG, "JPEG dimensions: %dx%d", pic_info.width, pic_info.height);
+  ESP_LOGI(TAG, "[PIC_INFO DEBUG] sizeof(pic_info)=%zu, width=%d, height=%d",
+           sizeof(pic_info), pic_info.width, pic_info.height);
 
   width = pic_info.width;
   height = pic_info.height;
@@ -483,13 +485,16 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
     return false;
   }
 
-  // Configure decoder using current directory's YAML-configured values
+  // Configure decoder - try hardcoded values matching old working code exactly
   jpeg_decode_cfg_t decode_cfg = {};
-  decode_cfg.output_format = static_cast<jpeg_dec_output_format_t>(current_dir->jpeg_output_format);
-  decode_cfg.rgb_order = static_cast<jpeg_dec_rgb_element_order_t>(current_dir->jpeg_rgb_order);
-  decode_cfg.conv_std = static_cast<jpeg_yuv_rgb_conv_std_t>(current_dir->jpeg_color_space);
+  decode_cfg.output_format = JPEG_DECODE_OUT_FORMAT_RGB565;  // Use constant like old code
+  decode_cfg.rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_RGB;      // RGB (value 0)
+  // conv_std left as 0 (default) like old code
 
-  // Debug: Log all parameters before decode
+  ESP_LOGI(TAG, "[HARDCODE TEST] Using hardcoded decode_cfg matching old working code");
+
+  // Debug: Log struct size and all parameters
+  ESP_LOGI(TAG, "[DECODE DEBUG] sizeof(jpeg_decode_cfg_t) = %zu bytes", sizeof(jpeg_decode_cfg_t));
   ESP_LOGI(TAG, "[DECODE DEBUG] Decoder handle: %p", hw_decoder);
   ESP_LOGI(TAG, "[DECODE DEBUG] Input buffer: %p (size: %u, aligned: %s)", aligned_input, input_size,
            ((uintptr_t)aligned_input % 16 == 0) ? "YES" : "NO");


### PR DESCRIPTION
Testing if the issue is with numeric values vs constant names. Using exact same constants as old storage_image code:
- JPEG_DECODE_OUT_FORMAT_RGB565 (instead of 0x02000002)
- JPEG_DEC_RGB_ELEMENT_ORDER_RGB (instead of numeric 0)
- conv_std left as 0 (default)

This will help identify if the problem is with the values or something else.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
