### PR TITLE
[picture_viewer] Fix linker error for platform-specific decoder methods

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -65,9 +65,13 @@ void PictureViewer::setup() {
     return;
   }
 
-  // Get and log decoder handle to verify it's valid
+  // Log decoder type based on platform
+#ifdef USE_HARDWARE_JPEG_DECODER
   jpeg_decoder_handle_t test_handle = this->transcoder_->get_jpeg_decoder();
-  ESP_LOGI(TAG, "Using transcoder for JPEG decoding (decoder handle: %p)", test_handle);
+  ESP_LOGI(TAG, "Using transcoder hardware JPEG decoder (ESP32-P4, handle: %p)", test_handle);
+#elif defined(USE_ESP_JPEG_DECODER)
+  ESP_LOGI(TAG, "Using transcoder ESP-JPEG decoder (ESP32-S2/S3)");
+#endif
 #else
 #ifdef USE_JPEGDEC
   // Initialize JPEGDec library (fallback when transcoder not available)


### PR DESCRIPTION
Fixed "undefined reference to get_jpeg_decoder()" by making decoder method calls platform-specific in setup():
- Only call get_jpeg_decoder() when USE_HARDWARE_JPEG_DECODER is defined (ESP32-P4)
- For USE_ESP_JPEG_DECODER (ESP32-S2/S3), just log decoder type
- For USE_JPEGDEC (other platforms), use existing JPEGDec initialization

The transcoder component provides different decoder APIs per platform, so picture_viewer must only call methods that exist for the current platform.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
