### PR TITLE
[transcoder][picture_viewer] Fix define ordering in Python codegen

### DIFF
--- a/esphome/components/picture_viewer/__init__.py
+++ b/esphome/components/picture_viewer/__init__.py
@@ -107,10 +107,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 async def to_code(config):
     """Generate code for picture_viewer component"""
-    var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
-
-    # Add defines for features used in this component's C++ code
+    # Set all defines FIRST (before component registration)
     # Transcoder is always loaded via AUTO_LOAD
     cg.add_define("USE_TRANSCODER")
 
@@ -131,12 +128,21 @@ async def to_code(config):
         # Non-ESP32 platforms use JPEGDec fallback
         cg.add_define("USE_JPEGDEC")
 
+    # Add conditional defines based on configuration
+    if CONF_FILE_MANAGER_ID in config:
+        cg.add_define("USE_STORAGE_HOST")
+
+    if CONF_CANVAS_ID in config:
+        cg.add_define("USE_LVGL")
+
+    # Create and register component AFTER all defines are set
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
     # Link file manager if provided
     if CONF_FILE_MANAGER_ID in config:
         fm = await cg.get_variable(config[CONF_FILE_MANAGER_ID])
         cg.add(var.set_file_manager(fm))
-        # Add define when storage_host is used
-        cg.add_define("USE_STORAGE_HOST")
 
     # Link LVGL canvas if provided
     if CONF_CANVAS_ID in config:
@@ -145,8 +151,6 @@ async def to_code(config):
         cg.add(var.set_canvas_id(str(config[CONF_CANVAS_ID])))
         # Set the canvas object pointer (canvas is already lv_obj_t*)
         cg.add(var.set_canvas(canvas))
-        # Add define when LVGL is used
-        cg.add_define("USE_LVGL")
 
     # Link display if provided
     if CONF_DISPLAY_ID in config:

--- a/esphome/components/transcoder/__init__.py
+++ b/esphome/components/transcoder/__init__.py
@@ -78,9 +78,6 @@ def require_h264_encoder():
 
 async def to_code(config):
     """Configure transcoder component based on platform and requirements."""
-    var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
-
     # Get registered codec requirements
     requirements = CORE.data.get("transcoder_requirements", set())
     if not requirements:
@@ -92,6 +89,10 @@ async def to_code(config):
 
     _LOGGER.info("Transcoder requirements: %s", ", ".join(sorted(requirements)))
 
+    # Set global transcoder accessor flag FIRST (before component registration)
+    # Note: global_transcoder is set to 'this' in Transcoder constructor
+    cg.add_define("USE_TRANSCODER")
+
     # Only configure for ESP32 platforms
     if not CORE.is_esp32:
         _LOGGER.info("Transcoder: Non-ESP32 platform, using fallback codecs")
@@ -99,6 +100,9 @@ async def to_code(config):
         if CODEC_JPEG_DECODER in requirements:
             cg.add_library("bodmer/JPEGDecoder", "1.8.0")
             cg.add_define("USE_JPEGDEC")
+        # Create and register component AFTER defines are set
+        var = cg.new_Pvariable(config[CONF_ID])
+        await cg.register_component(var, config)
         return
 
     from esphome.components.esp32 import get_esp32_variant, add_idf_component
@@ -173,6 +177,6 @@ async def to_code(config):
                 "H.264 codec requested but only available on ESP32-P4/S3 (current: %s)", variant
             )
 
-    # Set global transcoder accessor flag
-    # Note: global_transcoder is set to 'this' in Transcoder constructor
-    cg.add_define("USE_TRANSCODER")
+    # Create and register component AFTER all defines are set
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)


### PR DESCRIPTION
Move all cg.add_define() calls to happen before cg.new_Pvariable() and cg.register_component() in both transcoder and picture_viewer components.

This ensures defines are set before C++ files are added to the build, preventing linker errors where methods wrapped in #ifdef (like get_jpeg_decoder()) are not compiled when the define is missing.

Follows the pattern used by other ESPHome components (mdns, network) where defines must be set before component registration.

Fixes linker error: undefined reference to
esphome::transcoder::Transcoder::get_jpeg_decoder()

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
