### PR TITLE
[transcoder][picture_viewer] Fix variant string matching

### DIFF
--- a/esphome/components/picture_viewer/__init__.py
+++ b/esphome/components/picture_viewer/__init__.py
@@ -115,15 +115,10 @@ async def to_code(config):
     from esphome.core import CORE
     if CORE.is_esp32:
         from esphome.components.esp32 import get_esp32_variant
-        from esphome.components.esp32.const import (
-            VARIANT_ESP32S2,
-            VARIANT_ESP32S3,
-            VARIANT_ESP32P4,
-        )
         variant = get_esp32_variant()
-        if variant in (VARIANT_ESP32S2, VARIANT_ESP32S3):
+        if "S2" in variant or "S3" in variant:
             cg.add_define("USE_ESP_JPEG_DECODER")
-        elif variant == VARIANT_ESP32P4:
+        elif "P4" in variant:
             cg.add_define("USE_HARDWARE_JPEG_DECODER")
         else:
             # Fallback for all other ESP32 variants

--- a/esphome/components/transcoder/__init__.py
+++ b/esphome/components/transcoder/__init__.py
@@ -3,6 +3,12 @@ import logging
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.components.esp32 import (
+    VARIANT_ESP32S2,
+    VARIANT_ESP32S3,
+    VARIANT_ESP32P4,
+    add_idf_component,
+)
 from esphome.const import CONF_ID
 from esphome.core import CORE
 
@@ -105,12 +111,7 @@ async def to_code(config):
         await cg.register_component(var, config)
         return
 
-    from esphome.components.esp32 import get_esp32_variant, add_idf_component
-    from esphome.components.esp32.const import (
-        VARIANT_ESP32S2,
-        VARIANT_ESP32S3,
-        VARIANT_ESP32P4,
-    )
+    from esphome.components.esp32 import get_esp32_variant
 
     variant = get_esp32_variant()
 
@@ -122,7 +123,7 @@ async def to_code(config):
 
     # ========== JPEG Codec Support ==========
     if jpeg_needed:
-        if variant in (VARIANT_ESP32S2, VARIANT_ESP32S3):
+        if "S2" in variant or "S3" in variant:
             # ESP32-S2/S3: Use esp_jpeg from ESP Component Registry
             add_idf_component(name="espressif/esp_jpeg", ref="1.3.1")
             if CODEC_JPEG_DECODER in requirements:
@@ -134,7 +135,7 @@ async def to_code(config):
             cg.add_define("TRANSCODER_JPEG_AVAILABLE")
             _LOGGER.info("Enabled esp_jpeg codec v1.3.1 for %s", variant)
 
-        elif variant == VARIANT_ESP32P4:
+        elif "P4" in variant:
             # ESP32-P4: Hardware JPEG codec
             if CODEC_JPEG_DECODER in requirements:
                 cg.add_define("USE_HARDWARE_JPEG_DECODER")
@@ -157,7 +158,7 @@ async def to_code(config):
 
     # ========== H.264 Codec Support ==========
     if h264_needed:
-        if variant in (VARIANT_ESP32P4, VARIANT_ESP32S3):
+        if "P4" in variant or "S3" in variant:
             # ESP32-P4: Hardware H.264 encoder + Software decoder
             # ESP32-S3: Software H.264 encoder/decoder
             # Use esp_h264 from ESP Component Registry
@@ -171,7 +172,7 @@ async def to_code(config):
                 cg.add_define("TRANSCODER_ENABLE_H264_ENCODER")
             cg.add_define("TRANSCODER_H264_AVAILABLE")
 
-            hw_type = "Hardware (P4)" if variant == VARIANT_ESP32P4 else "Software (S3)"
+            hw_type = "Hardware (P4)" if "P4" in variant else "Software (S3)"
             _LOGGER.info("Enabled esp_h264 codec v1.1.2 for %s - %s", variant, hw_type)
         else:
             _LOGGER.error(


### PR DESCRIPTION
Use substring matching ("P4" in variant) instead of exact comparison (variant == VARIANT_ESP32P4) because get_esp32_variant() may return strings like "ESP32-P4" with hyphens.

This fixes the issue where the P4 variant check was failing, causing USE_HARDWARE_JPEG_DECODER to not be defined, leading to linker errors.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
