### PR TITLE
[transcoder] Revert coroutine priority - not applicable

### DIFF
--- a/esphome/components/transcoder/__init__.py
+++ b/esphome/components/transcoder/__init__.py
@@ -10,7 +10,7 @@ from esphome.components.esp32 import (
     add_idf_component,
 )
 from esphome.const import CONF_ID
-from esphome.core import CORE, CoroPriority, coroutine_with_priority
+from esphome.core import CORE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,7 +82,6 @@ def require_h264_encoder():
     _LOGGER.debug("Transcoder: H.264 encoder required")
 
 
-@coroutine_with_priority(CoroPriority.NETWORK)
 async def to_code(config):
     """Configure transcoder component based on platform and requirements."""
     # Get registered codec requirements


### PR DESCRIPTION
Reverted @coroutine_with_priority(CoroPriority.NETWORK) as it makes no sense for transcoder. AUTO_LOAD already ensures execution order.

The linker issue must be due to a different cause.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
