### PR TITLE
[picture_viewer] Remove decoder defines - let transcoder handle them

### DIFF
--- a/esphome/components/picture_viewer/__init__.py
+++ b/esphome/components/picture_viewer/__init__.py
@@ -107,25 +107,9 @@ CONFIG_SCHEMA = cv.Schema(
 
 async def to_code(config):
     """Generate code for picture_viewer component"""
-    # Set all defines FIRST (before component registration)
-    # Transcoder is always loaded via AUTO_LOAD
+    # Set defines FIRST (before component registration)
+    # Transcoder is always loaded via AUTO_LOAD and sets decoder defines globally
     cg.add_define("USE_TRANSCODER")
-
-    # Add platform-specific JPEG decoder defines (matches transcoder logic)
-    from esphome.core import CORE
-    if CORE.is_esp32:
-        from esphome.components.esp32 import get_esp32_variant
-        variant = get_esp32_variant()
-        if "S2" in variant or "S3" in variant:
-            cg.add_define("USE_ESP_JPEG_DECODER")
-        elif "P4" in variant:
-            cg.add_define("USE_HARDWARE_JPEG_DECODER")
-        else:
-            # Fallback for all other ESP32 variants
-            cg.add_define("USE_JPEGDEC")
-    else:
-        # Non-ESP32 platforms use JPEGDec fallback
-        cg.add_define("USE_JPEGDEC")
 
     # Add conditional defines based on configuration
     if CONF_FILE_MANAGER_ID in config:


### PR DESCRIPTION
Picture_viewer should not set decoder-specific defines (USE_HARDWARE_JPEG_DECODER, USE_ESP_JPEG_DECODER, USE_JPEGDEC).

These are set globally by transcoder which is AUTO_LOADed and runs first. Picture_viewer only needs to set:
- USE_TRANSCODER
- USE_STORAGE_HOST (conditional)
- USE_LVGL (conditional)

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
