### PR TITLE
Add esp_jpeg and esp_h264 to global IDF component manifest

### DIFF
--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -5,6 +5,14 @@ dependencies:
     version: 2.1.1
   espressif/mdns:
     version: 1.8.2
+  espressif/esp_jpeg:
+    version: 1.3.1
+    rules:
+      - if: "target in [esp32s2, esp32s3, esp32p4]"
+  espressif/esp_h264:
+    version: 1.1.2
+    rules:
+      - if: "target in [esp32s3, esp32p4]"
   espressif/esp_wifi_remote:
     version: 1.1.5
     rules:


### PR DESCRIPTION
- Add espressif/esp_jpeg v1.3.1 for ESP32-S2/S3/P4 targets
- Add espressif/esp_h264 v1.1.2 for ESP32-S3/P4 targets
- This fixes toolchain selection issues for transcoder component

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
