### PR TITLE
[transcoder] Fix is_jpeg_decoder_available() lazy initialization

### DIFF
--- a/esphome/components/transcoder/transcoder.h
+++ b/esphome/components/transcoder/transcoder.h
@@ -79,8 +79,15 @@ class Transcoder : public Component {
 
   /**
    * @brief Check if JPEG decoder is available
+   * Triggers lazy initialization if not already done
    */
-  bool is_jpeg_decoder_available() { return this->jpeg_decoder_ != nullptr; }
+  bool is_jpeg_decoder_available() {
+    // Trigger lazy init if needed
+    if (this->jpeg_decoder_ == nullptr) {
+      this->get_jpeg_decoder();
+    }
+    return this->jpeg_decoder_ != nullptr;
+  }
 
 #elif defined(USE_ESP_JPEG_DECODER)
   /**


### PR DESCRIPTION
The is_jpeg_decoder_available() method was returning false during picture_viewer setup because the hardware decoder uses lazy initialization and hadn't been created yet.

Now is_jpeg_decoder_available() triggers the lazy initialization if the decoder is nullptr, ensuring it returns the correct availability status when called during component setup.

This fixes the "JPEG decoder not available in transcoder" error in picture_viewer.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
