### PR TITLE
[transcoder][picture_viewer] Add decoder release to work around ESP32…

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -525,6 +525,8 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
              aligned_input, input_size, aligned_output, output_size);
     free(aligned_input);
     free(aligned_output);
+    // Release decoder to work around ESP32-P4 state corruption bug
+    this->transcoder_->release_jpeg_decoder();
     return false;
   }
 
@@ -544,6 +546,10 @@ bool PictureViewer::decode_jpeg_hardware_(const std::vector<uint8_t> &jpeg_data,
   // Free aligned buffers
   free(aligned_input);
   free(aligned_output);
+
+  // Release decoder to work around ESP32-P4 state corruption bug
+  // This ensures decoder is recreated fresh for next image
+  this->transcoder_->release_jpeg_decoder();
 
   ESP_LOGD(TAG, "Decoded JPEG using hardware decoder: %dx%d", width, height);
   return true;

--- a/esphome/components/transcoder/transcoder.cpp
+++ b/esphome/components/transcoder/transcoder.cpp
@@ -117,6 +117,14 @@ jpeg_decoder_handle_t Transcoder::get_jpeg_decoder() {
   ESP_LOGI(TAG, "Hardware JPEG decoder initialized successfully (handle: %p)", this->jpeg_decoder_);
   return this->jpeg_decoder_;
 }
+
+void Transcoder::release_jpeg_decoder() {
+  if (this->jpeg_decoder_ != nullptr) {
+    jpeg_del_decoder_engine(this->jpeg_decoder_);
+    this->jpeg_decoder_ = nullptr;
+    ESP_LOGD(TAG, "Hardware JPEG decoder released (workaround for ESP32-P4 state corruption bug)");
+  }
+}
 #endif
 
 void Transcoder::dump_config() {

--- a/esphome/components/transcoder/transcoder.h
+++ b/esphome/components/transcoder/transcoder.h
@@ -78,6 +78,13 @@ class Transcoder : public Component {
   jpeg_decoder_handle_t get_jpeg_decoder();
 
   /**
+   * @brief Release hardware JPEG decoder (ESP32-P4)
+   * Deletes decoder to work around ESP32-P4 state corruption bug
+   * Must be called after each decode operation
+   */
+  void release_jpeg_decoder();
+
+  /**
    * @brief Check if JPEG decoder is available
    * Triggers lazy initialization if not already done
    */


### PR DESCRIPTION
…-P4 state corruption

ESP32-P4 hardware JPEG decoder has a known state corruption bug where the decoder fails after 2-3 operations (espressif/esp-idf#17040).

This implements the same workaround used in the old storage_image code: delete and recreate the decoder for each decode operation instead of reusing it.

Changes:
- Add release_jpeg_decoder() to transcoder API
- Call release after each successful/failed decode in picture_viewer
- Decoder is recreated fresh on next get_jpeg_decoder() call

This matches the old working storage_image behavior and should fix the ESP_ERR_INVALID_ARG failures on subsequent decodes.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
