### PR TITLE
[picture_viewer] Lower PSRAM allocation threshold from 1MB to 64KB

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -838,11 +838,11 @@ bool PictureViewer::read_file_(const std::string &path, std::vector<uint8_t> &da
 
 uint8_t *PictureViewer::allocate_image_buffer_(size_t size) {
 #ifdef ESP32
-  // For large images (>1MB), REQUIRE PSRAM to avoid heap fragmentation
-  if (size > 1024 * 1024) {
+  // For images >64KB, REQUIRE PSRAM to avoid heap fragmentation
+  if (size > 65536) {
     uint8_t *buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM));
     if (buffer == nullptr) {
-      ESP_LOGE(TAG, "Failed to allocate %zu bytes in PSRAM (required for large images)", size);
+      ESP_LOGE(TAG, "Failed to allocate %zu bytes in PSRAM (required for images >64KB)", size);
       return nullptr;
     }
     ESP_LOGD(TAG, "Allocated %zu bytes in PSRAM", size);


### PR DESCRIPTION
Fix MCU crash when decoding large images by requiring PSRAM for images >64KB instead of >1MB. ESP32-P4 has only 512KB heap but 32MB PSRAM, so allocating 2MB images in heap causes heap fragmentation and Guru Meditation Error.

Now all images >64KB will be allocated in PSRAM, preventing heap exhaustion.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
