### PR TITLE
[picture_viewer] Fix variable redeclaration in allocate_image_buffer_

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -837,10 +837,12 @@ bool PictureViewer::read_file_(const std::string &path, std::vector<uint8_t> &da
 }
 
 uint8_t *PictureViewer::allocate_image_buffer_(size_t size) {
+  uint8_t *buffer = nullptr;
+
 #ifdef USE_ESP32
   // For images >64KB, REQUIRE PSRAM to avoid heap fragmentation
   if (size > 65536) {
-    uint8_t *buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
     if (buffer == nullptr) {
       ESP_LOGE(TAG, "Failed to allocate %zu bytes in PSRAM (required for images >64KB)", size);
       return nullptr;
@@ -850,7 +852,7 @@ uint8_t *PictureViewer::allocate_image_buffer_(size_t size) {
   }
 
   // For smaller images, try PSRAM first, then fallback to heap
-  uint8_t *buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
   if (buffer != nullptr) {
     ESP_LOGD(TAG, "Allocated %zu bytes in PSRAM", size);
     return buffer;
@@ -860,7 +862,7 @@ uint8_t *PictureViewer::allocate_image_buffer_(size_t size) {
 #endif
 
   // Fallback to regular heap for smaller allocations
-  uint8_t *buffer = static_cast<uint8_t *>(malloc(size));
+  buffer = static_cast<uint8_t *>(malloc(size));
   if (buffer != nullptr) {
     ESP_LOGD(TAG, "Allocated %zu bytes in heap", size);
   }


### PR DESCRIPTION
Declare buffer variable once at the top of the function to avoid redeclaration error when USE_ESP32 is defined.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
