### PR TITLE
[picture_viewer] Add ESP32-P4 PSRAM cache coherency synchronization

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -7,6 +7,7 @@
 
 #ifdef ESP32
 #include "esp_heap_caps.h"
+#include "esp_cache.h"
 #endif
 
 #ifdef USE_HARDWARE_JPEG_DECODER
@@ -181,6 +182,16 @@ bool PictureViewer::show_image(size_t index) {
 
   // Copy decoded data to buffer
   std::memcpy(this->current_image_data_, rgb565_data.data(), this->current_image_size_);
+
+#ifdef USE_ESP32
+  // Synchronize cache to PSRAM (ESP32-P4 cache coherency)
+  // This ensures the CPU cache is written back to external PSRAM before GPU/LVGL accesses it
+  esp_err_t sync_ret = esp_cache_msync(this->current_image_data_, this->current_image_size_, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+  if (sync_ret != ESP_OK) {
+    ESP_LOGW(TAG, "Cache sync failed: %s (this may cause display issues)", esp_err_to_name(sync_ret));
+  }
+#endif
+
   this->current_image_width_ = width;
   this->current_image_height_ = height;
   this->current_index_ = index;


### PR DESCRIPTION
Fix Load access fault crash by adding esp_cache_msync() call after writing decoded image data to PSRAM. ESP32-P4 PSRAM access goes through CPU cache, requiring explicit cache-to-memory synchronization before GPU/LVGL can access the data.

Without this, the memcpy writes to cache but the data isn't flushed to PSRAM, causing Load access fault when LVGL tries to read from PSRAM memory.

Uses ESP_CACHE_MSYNC_FLAG_DIR_C2M (cache to memory writeback) and ESP_CACHE_MSYNC_FLAG_UNALIGNED to handle potentially unaligned buffers.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
