### PR TITLE
[picture_viewer] Add MALLOC_CAP_DMA for cache-coherent PSRAM allocation

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -840,14 +840,22 @@ uint8_t *PictureViewer::allocate_image_buffer_(size_t size) {
   uint8_t *buffer = nullptr;
 
 #ifdef USE_ESP32
-  // For images >64KB, REQUIRE PSRAM to avoid heap fragmentation
+  // For images >64KB, REQUIRE PSRAM with DMA capability (ensures cache coherency)
   if (size > 65536) {
+    // Try DMA-capable PSRAM first (automatic cache coherency on ESP32-P4)
+    buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA));
+    if (buffer != nullptr) {
+      ESP_LOGD(TAG, "Allocated %zu bytes in PSRAM (DMA-capable)", size);
+      return buffer;
+    }
+
+    // Fallback to regular PSRAM if DMA not available
     buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
     if (buffer == nullptr) {
       ESP_LOGE(TAG, "Failed to allocate %zu bytes in PSRAM (required for images >64KB)", size);
       return nullptr;
     }
-    ESP_LOGD(TAG, "Allocated %zu bytes in PSRAM", size);
+    ESP_LOGD(TAG, "Allocated %zu bytes in PSRAM (non-DMA)", size);
     return buffer;
   }
 


### PR DESCRIPTION
Try DMA-capable PSRAM allocation first (MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA) which should provide automatic cache coherency on ESP32-P4. This avoids the need for manual cache synchronization via esp_cache_msync (which isn't available in current ESP-IDF version).

DMA-capable memory ensures hardware can access it with proper cache handling, which should prevent Load access fault when LVGL reads from PSRAM.

Falls back to regular PSRAM if DMA allocation fails.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
