### PR TITLE
[picture_viewer] Use cache-aligned PSRAM allocation matching ESP-IDF …

### DIFF
--- a/esphome/components/picture_viewer/picture_viewer.cpp
+++ b/esphome/components/picture_viewer/picture_viewer.cpp
@@ -7,6 +7,7 @@
 
 #ifdef ESP32
 #include "esp_heap_caps.h"
+#include "esp_cache.h"
 #endif
 
 #ifdef USE_HARDWARE_JPEG_DECODER
@@ -840,22 +841,31 @@ uint8_t *PictureViewer::allocate_image_buffer_(size_t size) {
   uint8_t *buffer = nullptr;
 
 #ifdef USE_ESP32
-  // For images >64KB, REQUIRE PSRAM with DMA capability (ensures cache coherency)
+  // For images >64KB, use cache-aligned PSRAM allocation (matches ESP-IDF JPEG driver approach)
   if (size > 65536) {
-    // Try DMA-capable PSRAM first (automatic cache coherency on ESP32-P4)
-    buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA));
-    if (buffer != nullptr) {
-      ESP_LOGD(TAG, "Allocated %zu bytes in PSRAM (DMA-capable)", size);
-      return buffer;
+    // Get cache alignment requirement for PSRAM
+    size_t cache_align = 0;
+    esp_err_t ret = esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &cache_align);
+
+    if (ret == ESP_OK && cache_align > 0) {
+      // Align size up to cache line boundary (like JPEG decoder output buffers)
+      size_t aligned_size = (size + cache_align - 1) & ~(cache_align - 1);
+
+      // Allocate cache-aligned PSRAM (matches jpeg_alloc_decoder_mem for output buffers)
+      buffer = static_cast<uint8_t *>(heap_caps_aligned_calloc(cache_align, 1, aligned_size, MALLOC_CAP_SPIRAM));
+      if (buffer != nullptr) {
+        ESP_LOGD(TAG, "Allocated %zu bytes in cache-aligned PSRAM (align=%zu)", aligned_size, cache_align);
+        return buffer;
+      }
     }
 
-    // Fallback to regular PSRAM if DMA not available
+    // Fallback to regular PSRAM if cache-aligned allocation fails
     buffer = static_cast<uint8_t *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
     if (buffer == nullptr) {
       ESP_LOGE(TAG, "Failed to allocate %zu bytes in PSRAM (required for images >64KB)", size);
       return nullptr;
     }
-    ESP_LOGD(TAG, "Allocated %zu bytes in PSRAM (non-DMA)", size);
+    ESP_LOGD(TAG, "Allocated %zu bytes in PSRAM (non-aligned fallback)", size);
     return buffer;
   }
 


### PR DESCRIPTION
…JPEG driver

Changed allocation strategy to match ESP-IDF jpeg_alloc_decoder_mem() for output buffers:
- Get cache alignment via esp_cache_get_alignment()
- Align buffer size to cache line boundaries
- Use heap_caps_aligned_calloc() with cache alignment

This ensures proper cache coherency for PSRAM buffers on ESP32-P4, matching the official ESP-IDF JPEG decoder driver implementation. The driver uses this approach for output buffers that hardware writes to, which require cache coherency management.

Falls back to regular PSRAM if cache-aligned allocation fails.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
